### PR TITLE
ci: unnecessary "internal" label 

### DIFF
--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -36,10 +36,11 @@ jobs:
                 ? context.payload.pull_request.number
                 : context.payload.issue.number;
 
-            const triageLabel = process.env.IS_INTERNAL === 'true' ? 'internal' : 'needs triage';
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              labels: [triageLabel],
-            });
+            if (process.env.IS_INTERNAL !== 'true') {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['needs triage'],
+              });
+            }


### PR DESCRIPTION
## Description

Label "internal" is unnecessarily put into the PRs when the author is a core team member. This is fixed in autolabel script

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [x] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->

#EDKUI-001
