### PR TITLE
fix: support custom icon components in icon props for button buttongroup card chip and dataview

### DIFF
--- a/src/lib/components/Accordion/Accordion.stories.tsx
+++ b/src/lib/components/Accordion/Accordion.stories.tsx
@@ -6,6 +6,7 @@ const meta: Meta<typeof Accordion> = {
   component: Accordion,
   argTypes: {
     expanded: { table: { defaultValue: { summary: "false" } } },
+    icon: { description: "Icon name (string) or a custom icon component (ReactElement), e.g. `<FontAwesomeIcon />`" },
   },
   args: {
     text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae fermentum arcu, vitae dignissim quam. Suspendisse eu nisi

--- a/src/lib/components/Accordion/Accordion.test.tsx
+++ b/src/lib/components/Accordion/Accordion.test.tsx
@@ -40,6 +40,11 @@ describe("Accordion", () => {
     expect(screen.getByText("home")).toBeInTheDocument();
   });
 
+  it("should render icon component when icon prop is given as a component", () => {
+    render(<Accordion title="Accordion Title" icon={<span data-testid="custom-icon">★</span>} />);
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
   it("should trigger the event given in the onToggle prop when toggled", () => {
     const handleToggle = jest.fn();
     const { container } = render(<Accordion title="Accordion Title" onToggle={handleToggle} />);

--- a/src/lib/components/Accordion/Accordion.tsx
+++ b/src/lib/components/Accordion/Accordion.tsx
@@ -52,7 +52,7 @@ const AccordionComponent = (props: PropsWithRefAndChildren<AccordionProps, HTMLD
   return (
     <div className={classNames} style={style} ref={ref} data-testid="accordionItem">
       <button className={styles.header} onClick={toggleAccordion}>
-        {icon && <Icon size="lg" name={icon} />}
+        {icon && (typeof icon === "string" ? <Icon size="lg" name={icon} /> : icon)}
         <span className={styles.title}>{title}</span>
         <MotifIcon className={styles.collapseIcon} size="lg" name="keyboard_arrow_down" />
       </button>

--- a/src/lib/components/Accordion/types.ts
+++ b/src/lib/components/Accordion/types.ts
@@ -17,7 +17,7 @@ export type AccordionProps = {
   title: string;
   index?: number;
   text?: string;
-  icon?: string;
+  icon?: string | ReactElement;
   onToggle?: () => void;
 } & AccordionDefaultableProps;
 

--- a/src/lib/components/Avatar/Avatar.stories.tsx
+++ b/src/lib/components/Avatar/Avatar.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof Avatar> = {
   argTypes: {
     size: { table: { defaultValue: { summary: "md" } } },
     variant: { table: { defaultValue: { summary: "secondary" } } },
+    icon: { description: "Icon name (string) or a custom icon component (ReactElement), e.g. `<FontAwesomeIcon />`" },
   },
   args: { letters: "AV" },
 };

--- a/src/lib/components/Avatar/Avatar.test.tsx
+++ b/src/lib/components/Avatar/Avatar.test.tsx
@@ -14,6 +14,11 @@ describe("Avatar", () => {
     expect(render(<Avatar icon="info" />).getByText("info")).toBeInTheDocument();
   });
 
+  it("should render icon component when icon prop is given as a component", () => {
+    render(<Avatar icon={<span data-testid="custom-icon">★</span>} />);
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
   it("should display image when image is set", () => {
     render(<Avatar image="https://picsum.photos/200" />);
     expect(screen.getByRole("img")).toHaveAttribute("src", "https://picsum.photos/200");

--- a/src/lib/components/Avatar/Avatar.tsx
+++ b/src/lib/components/Avatar/Avatar.tsx
@@ -22,7 +22,11 @@ const Avatar = (props: PropsWithRef<AvatarProps, HTMLDivElement>) => {
       ) : letters ? (
         <span>{letters.toUpperCase().substring(0, size === "xs" || size === "sm" ? 1 : 2)}</span>
       ) : icon ? (
-        <Icon name={icon} />
+        typeof icon === "string" ? (
+          <Icon name={icon} />
+        ) : (
+          icon
+        )
       ) : (
         <MotifIcon name="person" />
       )}

--- a/src/lib/components/Avatar/types.ts
+++ b/src/lib/components/Avatar/types.ts
@@ -1,6 +1,8 @@
+import type { ReactElement } from "react";
+
 export type AvatarProps = {
   image?: string;
-  icon?: string;
+  icon?: string | ReactElement;
   letters?: string;
 } & AvatarDefaultableProps;
 

--- a/src/lib/components/Badge/Badge.stories.tsx
+++ b/src/lib/components/Badge/Badge.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof Badge> = {
     max: { table: { defaultValue: { summary: "999" } } },
     align: { table: { defaultValue: { summary: "top-right" } } },
     children: { control: false },
+    icon: { description: "Icon name (string) or a custom icon component (ReactElement), e.g. `<FontAwesomeIcon />`" },
   },
   args: {
     content: "badge",

--- a/src/lib/components/Badge/Badge.test.tsx
+++ b/src/lib/components/Badge/Badge.test.tsx
@@ -84,6 +84,15 @@ describe("Badge", () => {
     expect(getByTestId(container, "badgeItem").textContent).not.toBe(testContent);
   });
 
+  it("should render icon component when icon prop is given as a component", () => {
+    const { container } = render(
+      <Badge icon={<span data-testid="custom-icon">★</span>}>
+        <button />
+      </Badge>,
+    );
+    expect(getByTestId(container, "badgeItem").querySelector("[data-testid='custom-icon']")).toBeInTheDocument();
+  });
+
   it("should render no text content when the dot is true", () => {
     const { container } = render(
       <Badge content="test" dot>

--- a/src/lib/components/Badge/Badge.tsx
+++ b/src/lib/components/Badge/Badge.tsx
@@ -19,7 +19,19 @@ const Badge = (props: PropsWithRefAndChildren<BadgeProps, HTMLDivElement>) => {
     ref,
   } = usePropsWithThemeDefaults("Badge", props);
 
-  const contentToRender = icon ? <Icon name={icon} size="xxs" /> : content ? max > 0 && Number(content) > max ? max + "+" : content : null;
+  const contentToRender = icon ? (
+    typeof icon === "string" ? (
+      <Icon name={icon} size="xxs" />
+    ) : (
+      icon
+    )
+  ) : content ? (
+    max > 0 && Number(content) > max ? (
+      max + "+"
+    ) : (
+      content
+    )
+  ) : null;
   const classNames = sanitizeModuleRootClasses(styles, className, [variant, align, dot && "dot"]);
 
   return (

--- a/src/lib/components/Badge/types.ts
+++ b/src/lib/components/Badge/types.ts
@@ -1,7 +1,9 @@
+import type { ReactElement } from "react";
+
 export type BadgeProps = {
   variant?: "primary" | "secondary" | "success" | "warning" | "danger" | "info";
   content?: string;
-  icon?: string;
+  icon?: string | ReactElement;
   dot?: boolean;
 } & BadgeDefaultableProps;
 

--- a/src/lib/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/lib/components/Breadcrumb/Breadcrumb.test.tsx
@@ -41,6 +41,12 @@ describe("Breadcrumb", () => {
     expect(screen.getByText("folder")).toBeInTheDocument();
   });
 
+  it("should render icon component when homeIcon prop is given as a component", () => {
+    const IconComponent = () => <span data-testid="custom-home-icon">home-svg</span>;
+    render(<Breadcrumb items={testItems} homeIcon={<IconComponent />} />);
+    expect(screen.getByTestId("custom-home-icon")).toBeInTheDocument();
+  });
+
   it("should render links to all items  without collapse", () => {
     render(<Breadcrumb items={testItems} maxVisibleItems={5} />);
 

--- a/src/lib/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/lib/components/Breadcrumb/Breadcrumb.tsx
@@ -51,7 +51,11 @@ const Breadcrumb = (props: PropsWithRef<BreadcrumbProps, HTMLUListElement>) => {
       <ul className={classNames} ref={ref} style={style}>
         {itemsToRender.length > 0 &&
           (homeIcon ? (
-            <Icon name={homeIcon} className={styles["homepage-icon"]} />
+            typeof homeIcon === "string" ? (
+              <Icon name={homeIcon} className={styles["homepage-icon"]} />
+            ) : (
+              <span className={styles["homepage-icon"]}>{homeIcon}</span>
+            )
           ) : (
             <MotifIcon name="home" className={styles["homepage-icon"]} />
           ))}

--- a/src/lib/components/Breadcrumb/types.ts
+++ b/src/lib/components/Breadcrumb/types.ts
@@ -1,9 +1,11 @@
+import type { ReactElement } from "react";
+
 export type BreadcrumbProps = {
   items: { label: string; path?: string }[];
 } & BreadcrumbDefaultableProps;
 
 export type BreadcrumbDefaultableProps = {
-  homeIcon?: string;
+  homeIcon?: string | ReactElement;
   maxVisibleItems?: number;
   collapsedPosition?: "left" | "right";
 };

--- a/src/lib/components/BusinessCard/BusinessCard.stories.tsx
+++ b/src/lib/components/BusinessCard/BusinessCard.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof BusinessCard> = {
   argTypes: {
     position: { table: { defaultValue: { summary: "center" } } },
     variant: { table: { defaultValue: { summary: "secondary" } } },
+    icon: { description: "Icon name (string) or a custom icon component (ReactElement), e.g. `<FontAwesomeIcon />`" },
     onClick: {
       control: { type: "boolean" },
       mapping: {

--- a/src/lib/components/BusinessCard/BusinessCard.tsx
+++ b/src/lib/components/BusinessCard/BusinessCard.tsx
@@ -38,7 +38,7 @@ const BusinessCard = (props: PropsWithRef<BusinessCardProps, HTMLDivElement>) =>
   return (
     <div className={classNames} ref={ref} onClick={onClick} style={style}>
       {image && <Avatar image={image} size="xxl" />}
-      {icon && <Icon name={icon} className={styles.icon} />}
+      {icon && (typeof icon === "string" ? <Icon name={icon} className={styles.icon} /> : icon)}
       {title && <span className={styles.title}>{title}</span>}
       {description && <span className={styles.description}>{description}</span>}
       {link && (

--- a/src/lib/components/BusinessCard/types.ts
+++ b/src/lib/components/BusinessCard/types.ts
@@ -1,4 +1,4 @@
-import type { MouseEvent } from "react";
+import type { MouseEvent, ReactElement } from "react";
 
 export type BusinessCardProps = {
   title?: string;
@@ -14,7 +14,7 @@ export type BusinessCardProps = {
     onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   };
   image?: string;
-  icon?: string;
+  icon?: string | ReactElement;
 } & BusinessCardDefaultableProps;
 
 export type BusinessCardDefaultableProps = {

--- a/src/lib/components/Button/Button.stories.tsx
+++ b/src/lib/components/Button/Button.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof Button> = {
     shape: { table: { defaultValue: { summary: "solid" } } },
     iconPosition: { table: { defaultValue: { summary: "left" } } },
     onClick: { action: "clicked" },
+    icon: { description: "Icon name (string) or a custom icon component (ReactElement), e.g. `<FontAwesomeIcon />`" },
   },
   args: {
     label: "Button",

--- a/src/lib/components/Button/Button.test.tsx
+++ b/src/lib/components/Button/Button.test.tsx
@@ -57,6 +57,12 @@ describe("Button", () => {
     expect(screen.queryByText("home")).toBeInTheDocument();
   });
 
+  it("should render icon component when icon prop is given as a component", () => {
+    const IconComponent = () => <span data-testid="custom-icon">icon-svg</span>;
+    render(<Button icon={<IconComponent />} />);
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
   it("should contain both the icon and the label when both props are set", () => {
     render(<Button icon="check" label="test label" />);
     expect(screen.getByText("check")).toBeInTheDocument();

--- a/src/lib/components/Button/Button.tsx
+++ b/src/lib/components/Button/Button.tsx
@@ -31,13 +31,18 @@ const Button = (props: PropsWithRef<ButtonProps, HTMLButtonElement>) => {
     size,
     pill && "pill",
     fluid && "fluid",
-    icon && `icon-${iconPosition}`,
+    !!icon && `icon-${iconPosition}`,
   ]);
 
   return (
     (icon || label) && (
       <button className={classNames} onClick={onClick} {...(disabled && { disabled })} type={htmlType} ref={ref} style={style}>
-        {icon && <Icon name={icon} className={styles.icon} size={size} />}
+        {icon &&
+          (typeof icon === "string" ? (
+            <Icon name={icon} className={styles.icon} size={size} />
+          ) : (
+            <span className={styles.icon}>{icon}</span>
+          ))}
         {label && <span>{label}</span>}
       </button>
     )

--- a/src/lib/components/Button/types.ts
+++ b/src/lib/components/Button/types.ts
@@ -1,8 +1,8 @@
-import type { MouseEvent } from "react";
+import type { MouseEvent, ReactElement } from "react";
 
 export type ButtonProps = {
   label?: string;
-  icon?: string;
+  icon?: string | ReactElement;
   iconPosition?: "left" | "right";
   disabled?: boolean;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;

--- a/src/lib/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/src/lib/components/ButtonGroup/ButtonGroup.test.tsx
@@ -129,6 +129,17 @@ describe("ButtonGroup.Item", () => {
     expect(getByText("folder")).toBeInTheDocument();
   });
 
+  it("should render icon component when icon prop is given as a component", () => {
+    const IconComponent = () => <span data-testid="custom-icon">icon-svg</span>;
+    const { getByTestId } = render(
+      <ButtonGroup>
+        <ButtonGroup.Item label="Item" icon={<IconComponent />} />
+      </ButtonGroup>,
+    );
+
+    expect(getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
   it("should render the label given in the label prop", () => {
     const { getByText } = render(
       <ButtonGroup>

--- a/src/lib/components/ButtonGroup/components/Button/Button.tsx
+++ b/src/lib/components/ButtonGroup/components/Button/Button.tsx
@@ -12,7 +12,8 @@ const Button = memo((props: Props) => {
 
   return (
     <button className={`${styles.button} ${styles[`button__${type}`]}`} type="button" disabled={disabled} onClick={action}>
-      {icon && <Icon name={icon} className={styles.icon} />} {label}
+      {icon && (typeof icon === "string" ? <Icon name={icon} className={styles.icon} /> : <span className={styles.icon}>{icon}</span>)}{" "}
+      {label}
     </button>
   );
 });

--- a/src/lib/components/ButtonGroup/components/ButtonGroupItem/ButtonGroupItem.tsx
+++ b/src/lib/components/ButtonGroup/components/ButtonGroupItem/ButtonGroupItem.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { MouseEventHandler, PropsWithChildren, useContext, useEffect } from "react";
+import { MouseEventHandler, PropsWithChildren, ReactElement, useContext, useEffect } from "react";
 import Button from "../Button/Button";
 import { ButtonGroupItemNumberOfChildrenContext } from "./ButtonGroupItemProvider";
 import ButtonWithDropdown from "../Button/ButtonWithDropdown";
 
 export type ButtonGroupItemProps = {
   label?: string;
-  icon?: string;
+  icon?: string | ReactElement;
   disabled?: boolean;
   action?: MouseEventHandler<HTMLButtonElement>;
 };

--- a/src/lib/components/Card/Card.stories.tsx
+++ b/src/lib/components/Card/Card.stories.tsx
@@ -9,6 +9,7 @@ const meta: Meta<typeof Card> = {
   argTypes: {
     imagePosition: { table: { defaultValue: { summary: "left" } } },
     variant: { table: { defaultValue: { summary: "secondary" } } },
+    icon: { description: "Icon name (string) or a custom icon component (ReactElement), e.g. `<FontAwesomeIcon />`" },
   },
   args: {
     title: "Card Header Title",

--- a/src/lib/components/Card/Card.test.tsx
+++ b/src/lib/components/Card/Card.test.tsx
@@ -62,6 +62,12 @@ describe("Card", () => {
     expect(screen.getByText("folder")).toBeInTheDocument();
   });
 
+  it("should render icon component when icon prop is given as a component", () => {
+    const IconComponent = () => <span data-testid="custom-icon">icon-svg</span>;
+    render(<Card icon={<IconComponent />} />);
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
   it("should render avatar text when avatarText is set", () => {
     render(<Card avatarText="AB" />);
     expect(screen.getByText("AB")).toBeInTheDocument();
@@ -142,6 +148,12 @@ describe("Card", () => {
   it("should render the icon given in the 'icon' property of the contentActionLink", () => {
     render(<Card contentActionLink={{ text: "Motif Link", href: "https://motif-ui.com/", icon: "arrow_forward" }} />);
     expect(screen.getByText("arrow_forward")).toBeInTheDocument();
+  });
+
+  it("should render icon component when contentActionLink icon prop is given as a component", () => {
+    const IconComponent = () => <span data-testid="custom-action-icon">icon-svg</span>;
+    render(<Card contentActionLink={{ text: "Motif Link", href: "https://motif-ui.com/", icon: <IconComponent /> }} />);
+    expect(screen.getByTestId("custom-action-icon")).toBeInTheDocument();
   });
 
   it("should render action button in the content part and trigger the given action when actionButton prop is set", () => {

--- a/src/lib/components/Card/components/CardActions.tsx
+++ b/src/lib/components/Card/components/CardActions.tsx
@@ -10,7 +10,7 @@ import { IconButtonProps } from "../../IconButton/types";
 type Props = {
   actionButton?: { text: string; onClick: (event: MouseEvent<HTMLButtonElement>) => void };
   alternateButton?: { text: string; onClick: (event: MouseEvent<HTMLButtonElement>) => void };
-  actionLink?: { text: string; href: string; icon?: string; targetBlank?: boolean };
+  actionLink?: { text: string; href: string; icon?: string | ReactElement; targetBlank?: boolean };
   buttons?: ReactElement<ButtonProps | LinkProps | IconButtonProps>[];
 };
 
@@ -30,7 +30,8 @@ const CardActions = (props: Props) => {
         {actionLink && (
           <a href={actionLink.href} {...(actionLink.targetBlank && { target: "_blank" })} className={styles.actionLink}>
             <span>{actionLink.text}</span>
-            {actionLink.icon && <Icon name={actionLink.icon} size="md" variant="primary" />}
+            {actionLink.icon &&
+              (typeof actionLink.icon === "string" ? <Icon name={actionLink.icon} size="md" variant="primary" /> : actionLink.icon)}
           </a>
         )}
       </div>

--- a/src/lib/components/Card/components/CardHeader.tsx
+++ b/src/lib/components/Card/components/CardHeader.tsx
@@ -2,11 +2,11 @@ import styles from "../Card.module.scss";
 import Avatar from "@/components/Avatar";
 import IconButton from "@/components/IconButton";
 import { sanitizeModuleClasses } from "../../../../utils/cssUtils";
-import type { MouseEvent } from "react";
+import { type MouseEvent, ReactElement } from "react";
 import ImageView from "@/components/ImageView";
 
 type Props = {
-  icon?: string;
+  icon?: string | ReactElement;
   avatarText?: string;
   title?: string;
   subtitle?: string;

--- a/src/lib/components/Card/types.ts
+++ b/src/lib/components/Card/types.ts
@@ -7,7 +7,7 @@ export type CardProps = {
   title?: string;
   subtitle?: string;
   avatarText?: string;
-  icon?: string;
+  icon?: string | ReactElement;
   image?: string;
   action?: { icon: string; onClick: (event: MouseEvent<HTMLButtonElement>) => void };
   contentTitle?: string;
@@ -17,7 +17,7 @@ export type CardProps = {
   contentLink?: { text: string; href: string; targetBlank?: boolean };
   contentActionButton?: { text: string; onClick: (event: MouseEvent<HTMLButtonElement>) => void };
   contentAlternateButton?: { text: string; onClick: (event: MouseEvent<HTMLButtonElement>) => void };
-  contentActionLink?: { text: string; href: string; icon?: string; targetBlank?: boolean };
+  contentActionLink?: { text: string; href: string; icon?: string | ReactElement; targetBlank?: boolean };
   buttons?: ReactElement<ButtonProps | LinkProps | IconButtonProps>[];
 } & CardDefaultableProps;
 

--- a/src/lib/components/Chip/Chip.stories.tsx
+++ b/src/lib/components/Chip/Chip.stories.tsx
@@ -10,6 +10,7 @@ const meta: Meta<typeof Chip> = {
     shape: { table: { defaultValue: { summary: "solid" } } },
     size: { table: { defaultValue: { summary: "md" } } },
     pill: { table: { defaultValue: { summary: "true" } } },
+    icon: { description: "Icon name (string) or a custom icon component (ReactElement), e.g. `<FontAwesomeIcon />`" },
   },
   args: {
     label: "Chips",

--- a/src/lib/components/Chip/Chip.test.tsx
+++ b/src/lib/components/Chip/Chip.test.tsx
@@ -13,6 +13,12 @@ describe("Chip", () => {
     expect(screen.getByText("test")).toBeDefined();
   });
 
+  it("should render icon component when icon prop is given as a component", () => {
+    const IconComponent = () => <span data-testid="custom-icon">icon-svg</span>;
+    render(<Chip label="test" icon={<IconComponent />} />);
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
   it("should be removed when close icon is clicked", () => {
     const { container } = render(<Chip label="test" closable />);
     expect(screen.getByTestId("iconButtonTestId")).toBeDefined();

--- a/src/lib/components/Chip/Chip.tsx
+++ b/src/lib/components/Chip/Chip.tsx
@@ -35,7 +35,12 @@ const Chip = (props: PropsWithRef<ChipProps, HTMLDivElement>) => {
   return (
     !deleted && (
       <div className={classNames} data-testid="chipItem" ref={ref} style={style}>
-        {icon && <Icon name={icon} size={size} className={styles["icon-left"]} />}
+        {icon &&
+          (typeof icon === "string" ? (
+            <Icon name={icon} size={size} className={styles["icon-left"]} />
+          ) : (
+            <span className={styles["icon-left"]}>{icon}</span>
+          ))}
         <span className={styles.label}>{label}</span>
         {closable && <MotifIconButton name="cancel" size={size} onClick={deleteHandler} className={styles["icon-close"]} />}
       </div>

--- a/src/lib/components/Chip/types.ts
+++ b/src/lib/components/Chip/types.ts
@@ -1,8 +1,9 @@
 import { Size4SM } from "../../types";
+import type { ReactElement } from "react";
 
 export type ChipProps = {
   label: string;
-  icon?: string;
+  icon?: string | ReactElement;
   variant?: ChipVariant;
   closable?: boolean;
   onClose?: () => void;

--- a/src/lib/components/DataView/DataView.test.tsx
+++ b/src/lib/components/DataView/DataView.test.tsx
@@ -141,6 +141,16 @@ describe("DataView", () => {
     expect(container.firstChild).toHaveClass("horizontal");
   });
 
+  it("should render icon component when icon prop is given as a component in DataView.Item", () => {
+    const IconComponent = () => <span data-testid="custom-icon">icon-svg</span>;
+    const { getByTestId } = render(
+      <DataView>
+        <DataView.Item label="Name" icon={<IconComponent />} />
+      </DataView>,
+    );
+    expect(getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
   it("should render the children of DataView.Item", () => {
     const { getByText } = render(
       <DataView>

--- a/src/lib/components/DataView/DataViewItem.tsx
+++ b/src/lib/components/DataView/DataViewItem.tsx
@@ -11,7 +11,7 @@ const DataViewItem = (props: PropsWithRefAndChildren<DataViewItemProps, HTMLDivE
   return (
     <div className={classNames} ref={ref} style={style}>
       <span className={styles.title}>
-        {icon && <Icon name={icon} className={styles.icon} />}
+        {icon && (typeof icon === "string" ? <Icon name={icon} className={styles.icon} /> : <span className={styles.icon}>{icon}</span>)}
         {label}
       </span>
       {children ? <div className={styles.value}>{children}</div> : <span className={styles.value}>{value}</span>}

--- a/src/lib/components/DataView/types.ts
+++ b/src/lib/components/DataView/types.ts
@@ -15,9 +15,11 @@ export type DataViewDefaultableProps = {
   orientation?: "horizontal" | "vertical";
 };
 
+import type { ReactElement } from "react";
+
 export type DataViewItemProps = {
   label: string;
   value?: string | number;
-  icon?: string;
+  icon?: string | ReactElement;
   variant?: "primary" | "info" | "success" | "warning" | "danger";
 };


### PR DESCRIPTION

## Description

- `icon` prop now accepts both `string` (icon name) and `ReactElement` (e.g. `<FontAwesomeIcon />`) in Button, ButtonGroup, Card, Chip and Dataview components
- Updated rendering logic with `typeof icon === "string"` check
- Added tests for component icon usage
- Updated Storybook argTypes descriptions

<!-- Please describe your changes and how this PR provides a solution -->

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [x] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

## Checklist

- [ ] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->

Closes [#EDKUI-1155]