### PR TITLE
fix: navbar submenu container size is fixed as same as parent

### DIFF
--- a/src/lib/components/NavBar/NavBar.module.scss
+++ b/src/lib/components/NavBar/NavBar.module.scss
@@ -63,6 +63,7 @@ $variants: ("neutral", "primary", "secondary", "info", "danger", "warning", "suc
   border: solid var(--base-sizing-1x) var(--theme-color-border-light-default);
   border-radius: var(--theme-sizing-radius-default);
   @include shadow(4);
+  min-width: 100%;
 
   .subMenu {
     top: calc(-1 * var(--base-sizing-1x));


### PR DESCRIPTION
## Description

Submenu container size is fixed as same as parent container size. Max-width and container refactoring will be discussed in advance. 

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<img width="512" height="303" alt="Screenshot 2026-04-15 at 16 58 07" src="https://github.com/user-attachments/assets/f035820a-192a-40fa-9b6e-c1c54c1d3e81" />

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [x] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

```code
     <NavBar
        logo={{ href: "https://motif-ui.com/", imgPath: "https://cdn.jsdelivr.net/gh/motif-ui/assets/images/motifui-logo.svg" }}
        mainMenu={{
          items: [
            { label: "Home", icon: "home" },
            {
              label: "Contact",
              icon: "mail",
              items: [
                { icon: "home", label: "Easy Peasy" },
                { icon: "folder", label: "Lemon Squeezy" },
              ],
            },
          ],
          subMenuDirection: "right",
        }}
        actionMenu={{
          items: [{ label: "User", icon: "person", items: [{ label: "Profile" }, { label: "Logout", icon: "close" }] }],
          subMenuDirection: "left",
        }}
        search={{ onSubmit: query => alert(query) }}
      />
```

[#EDKUI-1353]
