### PR TITLE
fix: accordion expanded prop collapsing issue

### DIFF
--- a/src/lib/components/Accordion/Accordion.tsx
+++ b/src/lib/components/Accordion/Accordion.tsx
@@ -36,7 +36,7 @@ const AccordionComponent = (props: PropsWithRefAndChildren<AccordionProps, HTMLD
   }, [expanded]);
 
   useEffect(() => {
-    if (groupEnabled && !multiExpand) {
+    if (groupEnabled && !multiExpand && expandedIndex !== undefined) {
       toggle(expandedIndex === index);
     }
   }, [expandedIndex, groupEnabled, index, multiExpand, toggle]);

--- a/src/lib/components/Accordion/AccordionGroup/AccordionGroup.test.tsx
+++ b/src/lib/components/Accordion/AccordionGroup/AccordionGroup.test.tsx
@@ -71,4 +71,18 @@ describe("AccordionGroup", () => {
     expect(accordions[0]).toHaveClass("expanded");
     expect(accordions[1]).not.toHaveClass("expanded");
   });
+
+  it("should remain expanded on mount when expanded prop is true inside a multiExpand=false group", () => {
+    render(
+      <AccordionGroup multiExpand={false}>
+        <Accordion title="Accordion Title 1" index={0} expanded />
+        <Accordion title="Accordion Title 2" index={1} />
+        <Accordion title="Accordion Title 3" index={2} />
+      </AccordionGroup>,
+    );
+    const accordions = screen.getAllByTestId("accordionItem");
+    expect(accordions[0]).toHaveClass("expanded");
+    expect(accordions[1]).not.toHaveClass("expanded");
+    expect(accordions[2]).not.toHaveClass("expanded");
+  });
 });


### PR DESCRIPTION
## Description

- `AccordionGroup` initializes `expandedIndex` as `undefined`; on mount the 
  group-sync effect was firing `toggle(undefined === index)` = `toggle(false)`, 
  overriding the `expanded` prop and immediately closing the accordion
- Added `expandedIndex !== undefined` guard so the group-sync effect only runs 
  after actual user interaction

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

```
<Accordion.Group multiExpand={false} condensed>
    <Accordion index={0} expanded icon="folder" title="Accordion 1" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
    <Accordion index={1} title="Accordion 2" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
    <Accordion index={2} title="Accordion 3">
        <div className="px-4 pb-6 text-[14px] leading-8 text-amber-700 bg-purple-100 text-center">Custom HTML content</div>
    </Accordion>
    <Accordion index={3} icon="person" title="Accordion 4" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
</Accordion.Group>

```
Closes [#EDKUI-1364]
