### PR TITLE
fix: min-width for form is removed

### DIFF
--- a/src/lib/components/Form/Form.module.scss
+++ b/src/lib/components/Form/Form.module.scss
@@ -9,7 +9,6 @@ $sizes: (
 );
 
 .Root {
-  min-width: min-content;
   display: flex;
   flex-direction: column;
 }

--- a/src/lib/components/Form/Form.module.scss
+++ b/src/lib/components/Form/Form.module.scss
@@ -17,6 +17,10 @@ $sizes: (
   display: flex;
 }
 
+.horizontal {
+  display: inline-flex;
+}
+
 .horizontal .fields {
   display: inline-flex;
   align-items: flex-start;

--- a/src/lib/components/Form/Form.module.scss
+++ b/src/lib/components/Form/Form.module.scss
@@ -9,10 +9,10 @@ $sizes: (
 );
 
 .Root {
-  display: flex;
   flex-direction: column;
 }
 
+.vertical,
 .submitArea {
   display: flex;
 }


### PR DESCRIPTION
## Description

min-width css value under Form.module.css which causes error to define exact amount of width is deleted, error correction is checked with the installation of fixed library version inside motif react website.

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->

#EDKUI-1375
