### PR TITLE
fix: pass style prop through to Icon component

### DIFF
--- a/src/lib/components/Icon/Icon.tsx
+++ b/src/lib/components/Icon/Icon.tsx
@@ -8,7 +8,18 @@ import usePropsWithThemeDefaults from "../../motif/hooks/usePropsWithThemeDefaul
 import { sanitizeModuleRootClasses } from "../../../utils/cssUtils";
 
 const Icon = (props: PropsWithRefAndChildren<IconProps, HTMLSpanElement>) => {
-  const { iconClass, name, svgColorType, children, ref, color, size = "md", variant, className } = usePropsWithThemeDefaults("Icon", props);
+  const {
+    iconClass,
+    name,
+    svgColorType,
+    children,
+    ref,
+    color,
+    size = "md",
+    variant,
+    className,
+    style,
+  } = usePropsWithThemeDefaults("Icon", props);
   const { baseIconClass } = useMotifContext();
   const isChildMotifIcon = isValidElement(children) && (children.type as FunctionComponent<IconProps>).displayName === "Icon";
 
@@ -22,7 +33,7 @@ const Icon = (props: PropsWithRefAndChildren<IconProps, HTMLSpanElement>) => {
   ]);
 
   return (
-    <span className={classNames} style={{ ...(color && { color }) }} ref={ref}>
+    <span className={classNames} style={{ ...(color && { color }), ...style }} ref={ref}>
       {iconName || (!isChildMotifIcon && children)}
     </span>
   );


### PR DESCRIPTION
## Description

Pass style prop to Icon's root element so inline styles take effect.

<!-- Please describe your changes and how this PR provides a solution -->

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

## Checklist

- [ ] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->


Closes [#EDKUI-1383]
