### PR TITLE
style(Carousel): updated arrow position

### DIFF
--- a/src/lib/components/Carousel/Carousel.module.scss
+++ b/src/lib/components/Carousel/Carousel.module.scss
@@ -63,14 +63,14 @@ $theme: (
 .next {
   position: absolute;
   top: calc(50% - var(--base-sizing-20x));
-  right: var(--base-sizing-40x);
+  right: var(--base-sizing-16x);
 }
 
 .prev {
   position: absolute;
   top: calc(50% - var(--base-sizing-20x));
   transform: rotate(180deg);
-  left: var(--base-sizing-40x);
+  left: var(--base-sizing-16x);
 }
 
 .track {


### PR DESCRIPTION
## Description

Carousel arrow button position updated to 16px. Figma side was also updated with the same change.

## Type of Change

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [x] 🧹 Code Refactoring


## Screenshots / Preview

BEFORE:
<img width="675" height="604" alt="{E29E9A53-69A1-43B0-9788-E8CF91DC790D}" src="https://github.com/user-attachments/assets/b1e07051-bafb-4d42-89cd-e5a36c1bc8b2" />


AFTER:
<img width="683" height="583" alt="{F0477429-90A4-4552-BAB5-A515E406B013}" src="https://github.com/user-attachments/assets/0191392d-d7fd-400c-be5d-a8378ef8c8fa" />


## Checklist

- [ ] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated




Closes [#EDKUI-1389]: Internal purposes only 
