### PR TITLE
fix(Form): validateOnChange feature

### DIFF
--- a/src/docs/v1/form/formInputs.mdx
+++ b/src/docs/v1/form/formInputs.mdx
@@ -25,6 +25,14 @@ of a form using these components, please refer to [Components/Form](?path=/docs/
 </Form.Field>
 ```
 
+### InputDateRange [[↗]](?path=/docs/components-inputdaterange--docs)
+
+```jsx
+<Form.Field name="filterDateRange" label="Dates to Filter">
+  <InputDateRange />
+</Form.Field>
+```
+
 ### InputDateTime [[↗]](?path=/docs/components-inputdatetime--docs)
 
 ```jsx
@@ -120,11 +128,32 @@ of a form using these components, please refer to [Components/Form](?path=/docs/
 </Form.Field>
 ```
 
+### Textarea [[↗]](?path=/docs/components-textarea--docs)
+
+```jsx
+<Form.Field name="desc" label="Description">
+  <Textarea />
+</Form.Field>
+```
+
 ### UploadInput [[↗]](?path=/docs/components-upload-input--docs)
 
 ```jsx
 <Form.Field name="avatar" label="Profile Picture">
   <UploadInput
+    uploadRequest={{
+      url: "/api/upload",
+      method: "POST"
+    }}
+  />
+</Form.Field>
+```
+
+### UploadDragger [[↗]](?path=/docs/components-upload-dragger--docs)
+
+```jsx
+<Form.Field name="files" label="Additional Files">
+  <UploadDragger
     uploadRequest={{
       url: "/api/upload",
       method: "POST"

--- a/src/docs/v1/form/formInputs.mdx
+++ b/src/docs/v1/form/formInputs.mdx
@@ -141,10 +141,8 @@ of a form using these components, please refer to [Components/Form](?path=/docs/
 ```jsx
 <Form.Field name="avatar" label="Profile Picture">
   <UploadInput
-    uploadRequest={{
-      url: "/api/upload",
-      method: "POST"
-    }}
+    uploadRequest={{ url: "/api/upload", method: "POST" }}
+    deleteRequest={{ url: "/api/delete", method: "POST" }}
   />
 </Form.Field>
 ```
@@ -154,10 +152,8 @@ of a form using these components, please refer to [Components/Form](?path=/docs/
 ```jsx
 <Form.Field name="files" label="Additional Files">
   <UploadDragger
-    uploadRequest={{
-      url: "/api/upload",
-      method: "POST"
-    }}
+    uploadRequest={{ url: "/api/upload", method: "POST" }}
+    deleteRequest={{ url: "/api/delete", method: "POST" }}
   />
 </Form.Field>
 ```
@@ -167,10 +163,8 @@ of a form using these components, please refer to [Components/Form](?path=/docs/
 ```jsx
 <Form.Field name="documents" label="Documents">
   <UploadList
-    uploadRequest={{
-      url: "/api/upload",
-      method: "POST"
-    }}
+    uploadRequest={{ url: "/api/upload", method: "POST" }}
+    deleteRequest={{ url: "/api/delete", method: "POST" }}
     maxSize={5000000}
   />
 </Form.Field>

--- a/src/docs/v1/form/validation.mdx
+++ b/src/docs/v1/form/validation.mdx
@@ -17,8 +17,14 @@ Form is flexible in terms of validation rules. Each validation rule is defined a
 
 ```tsx
 type InputValidation = {
-  errorMessage: string; // Message displayed when validation fails
-  validate: (value: InputValue) => boolean; // Function that performs the validation
+  // Function that performs the validation
+  validate: (value: InputValue) => boolean;
+  // Message displayed when validation fails
+  errorMessage: string;
+  // Optional parameters for error message formatting
+  errorParams?: Record<string, unknown>;
+  // Identifies the validation whether the connected field(s) is required.
+  requiredValidation?: boolean;
 }
 ```
 
@@ -216,4 +222,22 @@ You can add multiple validation rules to a field. Those may include a combinatio
 >
   <InputText />
 </Form.Field>
+```
+
+## Validate on Change
+
+By default, validations are triggered when the form is submitted. However, you can enable real-time validation by using
+the `validateOnChange` prop on the `<Form>` component. When this prop is set to `true`, validations will be executed
+whenever the value of a field changes, providing immediate feedback to users.
+
+```jsx
+<Form validateOnChange onSubmit={() => {}}>
+  <Form.Field
+    name="email"
+    label="Email"
+    validations={[Validations.EMAIL]}
+  >
+    <InputText />
+  </Form.Field>
+</Form>
 ```

--- a/src/lib/components/Form/Form.mdx
+++ b/src/lib/components/Form/Form.mdx
@@ -7,45 +7,10 @@ import { getStaticPropNames } from "../../../utils/utils";
 
 ### Validation
 
-Validations are managed by `<Form.Field>`, `<Form.FieldGroup>`. There are some predefined validation rules under **Validations** class such as required, min, max, e-mail, etc:
+Form provides a flexible validation system using the `validations` prop available in `<Form.Field>` and
+`<Form.FieldGroup>` that actually manage the validations.
 
-<ul>
-  {getStaticPropNames(Validations).map(name => (
-    <li>{name}</li>
-  ))}
-</ul>
-
-There is always a possibility to use a custom validator. Each validation is simply a type which consists of a validate function and an error message:
-
-```js
-{
-    validate: (value?: string) => boolean;
-    errorMessage: string;
-    requiredValidation?: boolean; //adds asterisk to the label
-}
-```
-
-#### Custom Validation
-
-Here is an example of a simple custom validator which prevents the users sending a value which includes some dangerous numbers:
-
-```tsx
-  const customValidation: (dangerousNumbers: number[]) => InputValidation =
-    dangerousNumbers => ({
-      errorMessage: `Input should not include dangerous numbers of ${dangerousNumbers.toString()}`,
-      validate: value => {
-        const validated = !value?.split("").some(char => dangerousNumbers.some(dangerous => dangerous === parseInt(char)));
-        return validated;
-      },
-    }
-);
-
-//...
-
-<Form.Field name="input" validations={[Validations.customValidation([1, 3, 5])]}>
-  <InputText />
-</Form.Field>
-```
+Please refer to **[Validation ↗](?path=/docs/form-validation--docs)** section for detailed information.
 
 ### Submitted Value Types
 
@@ -136,3 +101,5 @@ also a layout customization option using the `<Grid>` component inside **Form**.
 ```
 
 > **Note:** For more please refer to [Form](?path=/docs/form-form--docs)
+
+validateOnChange ekleeeeeee

--- a/src/lib/components/Form/Form.mdx
+++ b/src/lib/components/Form/Form.mdx
@@ -101,5 +101,3 @@ also a layout customization option using the `<Grid>` component inside **Form**.
 ```
 
 > **Note:** For more please refer to [Form](?path=/docs/form-form--docs)
-
-validateOnChange ekleeeeeee

--- a/src/lib/components/Form/Form.tsx
+++ b/src/lib/components/Form/Form.tsx
@@ -21,13 +21,14 @@ const FormTemp = <T extends NameInputValue>(props: PropsWithRefAndChildren<FormP
     clearButtonLabel = t("g.clear"),
     dontClearOnSubmit,
     title,
+    validateOnChange,
     ref,
     style,
     className,
   } = usePropsWithThemeDefaults("Form", props);
 
   return (
-    <FormProvider formOrientation={formOrientation} size={size} labelOrientation={labelOrientation}>
+    <FormProvider formOrientation={formOrientation} size={size} labelOrientation={labelOrientation} validateOnChange={validateOnChange}>
       <FormComponent
         ref={ref}
         onSubmit={onSubmit}

--- a/src/lib/components/Form/context/FormContext.tsx
+++ b/src/lib/components/Form/context/FormContext.tsx
@@ -18,12 +18,13 @@ export const useForm = () => useContext(FormContext);
 
 export const FormProvider = (props: PropsWithChildren<FormProviderProps>) => {
   const { t } = useMotifContext();
-  const { formOrientation, labelOrientation, size, children } = props;
+  const { formOrientation, labelOrientation, size, children, validateOnChange } = props;
   const formStateRef = useRef<FormStateRefProps>({
     fields: {},
     values: {},
     validationRules: {},
     isValid: true,
+    pendingInitFields: new Set(),
   });
 
   /**
@@ -75,6 +76,7 @@ export const FormProvider = (props: PropsWithChildren<FormProviderProps>) => {
     if (validations) {
       formStateRef.current.validationRules[name] = validations;
     }
+    formStateRef.current.pendingInitFields.add(name);
   }, []);
 
   /**
@@ -109,6 +111,7 @@ export const FormProvider = (props: PropsWithChildren<FormProviderProps>) => {
       if (!formStateRef.current.validationRules[groupName] && !!groupValidations?.length) {
         formStateRef.current.validationRules[groupName] = groupValidations;
       }
+      formStateRef.current.pendingInitFields.add(groupName);
     },
     [],
   );
@@ -172,41 +175,38 @@ export const FormProvider = (props: PropsWithChildren<FormProviderProps>) => {
   );
 
   /**
-   * Validates the form by checking the values that are passed to form state by onChange event of the inputs
-   * using the validation rules. It sets the form state with the latest info after the validation and returns
-   * the values and error status.
+   * Validates a single field by name: runs its validation rules and checks for self-reported errors.
+   * Disabled fields are always considered valid. Sets the field's error via errorSetter on failure.
    *
-   * Since the form handles everything itself, values of disabled items are removed from the form state here.
-   *
-   * @returns {FormSubmitData}
+   * @param {string} name - key in fields/validationRules (group name for group fields)
+   * @returns {boolean} true if the field is valid
    */
+  const _validateField = useCallback(
+    (name: string): boolean => {
+      const { fields, validationRules, values } = formStateRef.current;
+      const field = fields[name];
+
+      if (!field || field.disabled) return true;
+
+      const hasRuleError = (validationRules[name] || []).some(validation => {
+        if (validation.validate(values[name])) return false;
+        field.errorSetter?.(t(validation.errorMessage, validation.errorParams));
+        return true;
+      });
+
+      return !hasRuleError && !field.hasInternalError;
+    },
+    [t],
+  );
+
   const validate = useCallback(() => {
-    let isValid = true;
-
     const sanitizedValues = _sanitizeValuesForDisabledItems();
-    const { validationRules, fields, values } = formStateRef.current;
-
-    for (const name of Object.keys(validationRules)) {
-      const rules = validationRules[name] || [];
-      for (const validation of rules) {
-        if (!fields[name]?.disabled && !validation.validate(values[name])) {
-          isValid = false;
-          fields[name]?.errorSetter?.(t(validation.errorMessage, validation.errorParams));
-          break;
-        }
-      }
-    }
-
-    // 3. Final check for self-reported errors from components
-    if (isValid) {
-      const hasAnySelfError = Object.values(fields).some(field => field?.hasInternalError);
-      if (hasAnySelfError) {
-        isValid = false;
-      }
-    }
+    const { fields } = formStateRef.current;
+    const isValid = Object.keys(fields).reduce((acc, name) => _validateField(name) && acc, true);
 
     return { isValid, values: sanitizedValues };
-  }, [_sanitizeValuesForDisabledItems, t]);
+  }, [_sanitizeValuesForDisabledItems, _validateField]);
+
   /**
    * This callback is used in the inputs the lift the value state up to the form by updating the form state. It also
    * removes the error state of the input if it has any
@@ -215,16 +215,31 @@ export const FormProvider = (props: PropsWithChildren<FormProviderProps>) => {
    * @param {string} groupName - name of the group if the input is in a group
    * @param {InputValue} value - value to update
    */
-  const notifyFormForFieldValueChange = useCallback((name: string, groupName: string | undefined, value?: InputValue) => {
-    const nameToUpdate = groupName ?? name;
-    formStateRef.current.values[nameToUpdate] = groupName
-      ? { ...(formStateRef.current.values[nameToUpdate] as object), [name]: value }
-      : value;
-    const field = formStateRef.current.fields[nameToUpdate];
-    if (field) {
-      field.errorSetter?.(undefined);
-      field.hasInternalError = undefined;
-    }
+  const notifyFormForFieldValueChange = useCallback(
+    (name: string, groupName: string | undefined, value?: InputValue) => {
+      const nameToUpdate = groupName ?? name;
+      formStateRef.current.values[nameToUpdate] = groupName
+        ? { ...(formStateRef.current.values[nameToUpdate] as object), [name]: value }
+        : value;
+      const field = formStateRef.current.fields[nameToUpdate];
+      if (field) {
+        field.errorSetter?.(undefined);
+        field.hasInternalError = undefined;
+
+        validateOnChange && !formStateRef.current.pendingInitFields.has(nameToUpdate) && _validateField(nameToUpdate);
+      }
+    },
+    [_validateField, validateOnChange],
+  );
+
+  /**
+   * Removes a field from the pending-init set, enabling validateOnChange for it going forward.
+   * Called via a deferred setTimeout in useRegisterFormField after all mount effects have run.
+   *
+   * @param {string} name - field name (or group name) to release from the init quarantine
+   */
+  const clearFieldFromPendingInit = useCallback((name: string) => {
+    formStateRef.current.pendingInitFields.delete(name);
   }, []);
 
   /**
@@ -307,6 +322,7 @@ export const FormProvider = (props: PropsWithChildren<FormProviderProps>) => {
         unregisterSingleField,
         unregisterGroupFieldItem,
         resetValues,
+        clearFieldFromPendingInit,
       }}
     >
       {children}

--- a/src/lib/components/Form/context/useRegisterFormField.tsx
+++ b/src/lib/components/Form/context/useRegisterFormField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect } from "react";
 import { useFormField } from "@/components/Form/context/FieldContext";
 import { useForm } from "@/components/Form/context/FormContext";
 import { InputValue, ItemRegisterType, UseRegisterFormFieldType } from "@/components/Form/types";
@@ -73,6 +73,22 @@ export const useRegisterFormField: UseRegisterFormFieldType = registerProps => {
         return () => unregisterSingleField(fieldName);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /**
+   * Releases this field from the pending-init quarantine after all mount effects have settled.
+   *
+   * Why setTimeout(0): React runs useEffect hooks in call order within a component, so this
+   * effect always fires before the input component's own mount-sync useEffect (which calls
+   * notifyFormForFieldValueChange with the initial value). Deferring to a macrotask guarantees
+   * the quarantine is only lifted after that mount-sync call has already been blocked.
+   */
+  useEffect(() => {
+    if (!shouldRegister) return;
+    const nameToMark = fieldContext.groupName ?? fieldContext.fieldName;
+    const timer = setTimeout(() => formContext.clearFieldFromPendingInit(nameToMark), 0);
+    return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/lib/components/Form/context/useRegisterFormField.tsx
+++ b/src/lib/components/Form/context/useRegisterFormField.tsx
@@ -97,7 +97,7 @@ export const useRegisterFormField: UseRegisterFormFieldType = registerProps => {
       fieldContext?.fieldName && formContext?.notifyFormForFieldValueChange(name ?? fieldContext.fieldName, fieldContext.groupName, value);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [fieldContext?.fieldName, fieldContext?.groupName, name],
+    [fieldContext?.fieldName, fieldContext?.groupName, name, formContext?.notifyFormForFieldValueChange],
   );
 
   const onFormFieldSelfError = useCallback(

--- a/src/lib/components/Form/test/Form.test.tsx
+++ b/src/lib/components/Form/test/Form.test.tsx
@@ -1153,7 +1153,7 @@ describe("Form", () => {
     expect(getFormField(0)).not.toHaveClass("error");
 
     // Checkbox: uncheck → error; recheck → clear
-    const checkboxInput = screen.getByTestId("checkbox").querySelector("input")!;
+    const checkboxInput = screen.getByTestId("checkbox").querySelector("input") as HTMLInputElement;
     await user.click(checkboxInput);
     expect(getFormField(1)).toHaveClass("error");
     expect(getFormField(1)).toHaveTextContent(requiredMessage);
@@ -1196,7 +1196,7 @@ describe("Form", () => {
     );
 
     const user = userEvent.setup();
-    const checkboxInputs = screen.getAllByTestId("checkbox").map(el => el.querySelector("input")!);
+    const checkboxInputs = screen.getAllByTestId("checkbox").map(el => el.querySelector("input") as HTMLInputElement);
 
     await user.click(checkboxInputs[0]);
     expect(getFormFieldGroup(0)).toHaveClass("error");

--- a/src/lib/components/Form/test/Form.test.tsx
+++ b/src/lib/components/Form/test/Form.test.tsx
@@ -1072,4 +1072,183 @@ describe("Form", () => {
       });
     });
   });
+
+  it("should not show any errors on initial render validateOnChange is set, even when all field values are invalid", () => {
+    render(
+      <Form onSubmit={mockFunction} validateOnChange>
+        <Form.Field name="inputText" validations={[Validations.Required]}>
+          <InputText />
+        </Form.Field>
+        <Form.Field name="inputPassword" validations={[Validations.Required]}>
+          <InputPassword />
+        </Form.Field>
+        <Form.Field name="textarea" validations={[Validations.Required]}>
+          <Textarea />
+        </Form.Field>
+        <Form.Field name="switch" validations={[Validations.Required]}>
+          <Switch />
+        </Form.Field>
+        <Form.Field name="radioGroup" validations={[Validations.Required]}>
+          <RadioGroup name="radioGroup">
+            <Radio value="Black" label="Black" />
+            <Radio value="White" label="White" />
+          </RadioGroup>
+        </Form.Field>
+        <Form.Field name="select" validations={[Validations.Required]}>
+          <Select data={data} />
+        </Form.Field>
+        <Form.FieldGroup name="sports" groupValidations={[Validations.Required, Validations.AtLeastN(2)]}>
+          <Checkbox name="volleyball" label="Volleyball" />
+          <Checkbox name="basketball" label="Basketball" />
+          <Checkbox name="tennis" label="Tennis" />
+        </Form.FieldGroup>
+      </Form>,
+    );
+
+    screen.queryAllByTestId("formField").forEach(field => expect(field).not.toHaveClass("error"));
+    expect(getFormFieldGroup(0)).not.toHaveClass("error");
+  });
+
+  it("should show and clear errors immediately for inputs when validateOnChange is set", async () => {
+    const minMessage = (min: number) => `You must enter at least ${min}`;
+    const minLengthMessage = (min: number) => `This field must be at least ${min} characters long`;
+    const requiredMessage = "Please fill in this field";
+
+    render(
+      <Form onSubmit={mockFunction} validateOnChange>
+        {/* 0: InputText — MinLength(3): invalid → valid */}
+        <Form.Field name="inputText" validations={[Validations.MinLength(3)]}>
+          <InputText />
+        </Form.Field>
+        {/* 1: Checkbox — Required, start checked: uncheck → error, recheck → clear */}
+        <Form.Field name="check" validations={[Validations.Required]}>
+          <Checkbox checked label="Accept" />
+        </Form.Field>
+        {/* 2: Slider — Min(50): below → error, above → clear */}
+        <Form.Field name="mySlider" validations={[Validations.Min(50)]}>
+          <Slider />
+        </Form.Field>
+        {/* 3: Select — Required: select item → no error */}
+        <Form.Field name="mySelect" validations={[Validations.Required]}>
+          <Select data={data} />
+        </Form.Field>
+        {/* 4: PinCode — RequiredArrayItems([0,1]): fill first only → error, fill second → clear */}
+        <Form.Field name="myPinCode" validations={[Validations.RequiredArrayItems([0, 1])]}>
+          <PinCode>
+            <PinCode.Item />
+            <PinCode.Item />
+          </PinCode>
+        </Form.Field>
+      </Form>,
+    );
+
+    const user = userEvent.setup();
+
+    // InputText: type 2 chars → error; type 1 more → clear
+    const textInput = screen.getByTestId("inputItem").querySelector("input")!;
+    await user.type(textInput, "ab");
+    expect(getFormField(0)).toHaveClass("error");
+    expect(getFormField(0)).toHaveTextContent(minLengthMessage(3));
+    await user.type(textInput, "c");
+    expect(getFormField(0)).not.toHaveClass("error");
+
+    // Checkbox: uncheck → error; recheck → clear
+    const checkboxInput = screen.getByTestId("checkbox").querySelector("input")!;
+    await user.click(checkboxInput);
+    expect(getFormField(1)).toHaveClass("error");
+    expect(getFormField(1)).toHaveTextContent(requiredMessage);
+    await user.click(checkboxInput);
+    expect(getFormField(1)).not.toHaveClass("error");
+
+    // Slider: change to 30 → error; change to 60 → clear
+    const sliderInput = screen.getByTestId("slider").querySelector("input[type='range']")!;
+    await act(() => fireEvent.change(sliderInput, { target: { value: "30" } }));
+    expect(getFormField(2)).toHaveClass("error");
+    expect(getFormField(2)).toHaveTextContent(minMessage(50));
+    await act(() => fireEvent.change(sliderInput, { target: { value: "60" } }));
+    expect(getFormField(2)).not.toHaveClass("error");
+
+    // Select: select an item → no error
+    await user.click(screen.queryByRole("combobox")!);
+    await user.click(screen.queryByText("Item 1")!);
+    expect(getFormField(3)).not.toHaveClass("error");
+
+    // PinCode: fill first item only → error; fill second → clear
+    const pinCodeInputs = screen.getAllByTestId("pinCodeItem");
+    await user.type(pinCodeInputs[0], "a");
+    expect(getFormField(4)).toHaveClass("error");
+    expect(getFormField(4)).toHaveTextContent(requiredMessage);
+    await user.type(pinCodeInputs[1], "b");
+    expect(getFormField(4)).not.toHaveClass("error");
+  });
+
+  it("should show group validation error on FieldGroup immediately as inputs change when validateOnChange is set", async () => {
+    const atLeastNMessage = (n: number) => `You must select at least ${n} items`;
+
+    render(
+      <Form onSubmit={mockFunction} validateOnChange>
+        <Form.FieldGroup name="sports" groupValidations={[Validations.AtLeastN(2)]}>
+          <Checkbox name="volleyball" label="Volleyball" />
+          <Checkbox name="basketball" label="Basketball" />
+          <Checkbox name="tennis" label="Tennis" />
+        </Form.FieldGroup>
+      </Form>,
+    );
+
+    const user = userEvent.setup();
+    const checkboxInputs = screen.getAllByTestId("checkbox").map(el => el.querySelector("input")!);
+
+    await user.click(checkboxInputs[0]);
+    expect(getFormFieldGroup(0)).toHaveClass("error");
+    expect(getFormFieldGroup(0)).toHaveTextContent(atLeastNMessage(2));
+
+    await user.click(checkboxInputs[1]);
+    expect(getFormFieldGroup(0)).not.toHaveClass("error");
+
+    await user.click(checkboxInputs[0]);
+    expect(getFormFieldGroup(0)).toHaveClass("error");
+  });
+
+  it("should not validate on change when validateOnChange is not set", async () => {
+    render(
+      <Form onSubmit={mockFunction}>
+        <Form.Field name="inputText" validations={[Validations.Required]}>
+          <InputText />
+        </Form.Field>
+      </Form>,
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByTestId("inputItem").querySelector("input")!;
+
+    await user.type(input, "hello");
+    await user.clear(input);
+    expect(getFormField(0)).not.toHaveClass("error");
+
+    await user.click(screen.getByText(t("g.submit")));
+    expect(getFormField(0)).toHaveClass("error");
+  });
+
+  it("should validate all fields on submit even when validateOnChange is set", async () => {
+    render(
+      <Form onSubmit={mockFunction} validateOnChange>
+        <Form.Field name="inputText" validations={[Validations.Required]}>
+          <InputText value="hello" />
+        </Form.Field>
+        <Form.Field name="inputPassword" validations={[Validations.Required]}>
+          <InputPassword />
+        </Form.Field>
+      </Form>,
+    );
+
+    const user = userEvent.setup();
+
+    expect(getFormField(0)).not.toHaveClass("error");
+    expect(getFormField(1)).not.toHaveClass("error");
+
+    await user.click(screen.getByText(t("g.submit")));
+
+    expect(getFormField(0)).not.toHaveClass("error");
+    expect(getFormField(1)).toHaveClass("error");
+  });
 });

--- a/src/lib/components/Form/test/Form.test.tsx
+++ b/src/lib/components/Form/test/Form.test.tsx
@@ -1145,7 +1145,7 @@ describe("Form", () => {
     const user = userEvent.setup();
 
     // InputText: type 2 chars → error; type 1 more → clear
-    const textInput = screen.getByTestId("inputItem").querySelector("input")!;
+    const textInput = screen.getByTestId("inputItem").querySelector("input") as HTMLInputElement;
     await user.type(textInput, "ab");
     expect(getFormField(0)).toHaveClass("error");
     expect(getFormField(0)).toHaveTextContent(minLengthMessage(3));

--- a/src/lib/components/Form/types.ts
+++ b/src/lib/components/Form/types.ts
@@ -17,6 +17,7 @@ export type FormDefaultableProps = {
   enableClearButton?: boolean;
   clearButtonLabel?: string;
   dontClearOnSubmit?: boolean;
+  validateOnChange?: boolean;
 };
 
 //////////////////////////////
@@ -80,6 +81,7 @@ export type FormProviderProps = {
   size: InputSize;
   formOrientation: Orientation;
   labelOrientation: Orientation;
+  validateOnChange?: boolean;
 };
 
 // Type of the form state reference
@@ -88,6 +90,7 @@ export type FormStateRefProps = {
   values: NameInputValue;
   validationRules: { [name: string]: InputValidation[] | undefined };
   isValid: boolean;
+  pendingInitFields: Set<string>;
 };
 
 // Props that are provided to the fields via FieldContext
@@ -103,6 +106,7 @@ export type FormContextType<T> = {
   labelOrientation: Orientation;
   validate: () => FormSubmitData<T>;
   resetValues: () => void;
+  clearFieldFromPendingInit: (name: string) => void;
 };
 
 // The type of the data returned when the form is submitted


### PR DESCRIPTION
## Description

There is a need for form component to validate the inputs when they change. This PR solves that issue.

- validateOnChange prop is introduced
- The most important part is that due to the nature of useEffect order, initial value of the inputs are validated, which is not wanted. So, there is a timeout mechanism included. This provides a macrotask, so the item is not validated initially.
- Tests are added
- There are some refactoring due to the seperation of the "whole form validate" - "item only validate"
- Documentation is updated (Including some out-of-PR form mdx updates)

## Type of Change

- [ ] 🆕 New Component
- [x] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [x] 🧹 Code Refactoring

## Screenshots / Preview

https://github.com/user-attachments/assets/c71bd7fb-25e0-40a9-a579-8dc2d1b09bd1

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [x] Tests added/updated and passing
- [x] Storybook story added/updated

## How to Test

by setting ``validateOnChange`` to true and try to change an input.

<!-- Closes [#EDKUI-1371]: Internal purposes only -->
