### PR TITLE
fix: prevent browser translation from breaking icons

### DIFF
--- a/src/lib/components/Accordion/AccordionGroup/__snapshots__/AccordionGroup.test.tsx.snap
+++ b/src/lib/components/Accordion/AccordionGroup/__snapshots__/AccordionGroup.test.tsx.snap
@@ -20,6 +20,8 @@ exports[`AccordionGroup should be rendered with only required props 1`] = `
         </span>
         <span
           class="Root lg motifIconsDefault collapseIcon"
+          lang="en"
+          translate="no"
         >
           keyboard_arrow_down
         </span>
@@ -47,6 +49,8 @@ exports[`AccordionGroup should be rendered with only required props 1`] = `
         </span>
         <span
           class="Root lg motifIconsDefault collapseIcon"
+          lang="en"
+          translate="no"
         >
           keyboard_arrow_down
         </span>

--- a/src/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -17,6 +17,8 @@ exports[`Accordion should be rendered with only required props 1`] = `
       </span>
       <span
         class="Root lg motifIconsDefault collapseIcon"
+        lang="en"
+        translate="no"
       >
         keyboard_arrow_down
       </span>

--- a/src/lib/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/lib/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`Alert should be rendered with only required props and should have defau
   >
     <span
       class="Root lg secondary motifIconsDefault"
+      lang="en"
+      translate="no"
     >
       info
     </span>

--- a/src/lib/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/lib/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -8,6 +8,8 @@ exports[`Avatar should be rendered with only required props 1`] = `
   >
     <span
       class="Root md motifIconsDefault"
+      lang="en"
+      translate="no"
     >
       person
     </span>

--- a/src/lib/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/lib/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`Breadcrumb should render with only required props 1`] = `
   >
     <span
       class="Root md motifIconsDefault homepage-icon"
+      lang="en"
+      translate="no"
     >
       home
     </span>
@@ -20,6 +22,8 @@ exports[`Breadcrumb should render with only required props 1`] = `
       </a>
       <span
         class="Root md motifIconsDefault right-icon"
+        lang="en"
+        translate="no"
       >
         arrow_forward_ios
       </span>
@@ -34,6 +38,8 @@ exports[`Breadcrumb should render with only required props 1`] = `
       </span>
       <span
         class="Root md motifIconsDefault right-icon"
+        lang="en"
+        translate="no"
       >
         arrow_forward_ios
       </span>
@@ -48,6 +54,8 @@ exports[`Breadcrumb should render with only required props 1`] = `
       </a>
       <span
         class="Root md motifIconsDefault right-icon"
+        lang="en"
+        translate="no"
       >
         arrow_forward_ios
       </span>

--- a/src/lib/components/Carousel/__snapshots__/Carousel.test.tsx.snap
+++ b/src/lib/components/Carousel/__snapshots__/Carousel.test.tsx.snap
@@ -70,6 +70,8 @@ exports[`Carousel should be rendered with only required props and should have de
     >
       <span
         class="Root md mtf-ui-icons xxl"
+        lang="en"
+        translate="no"
       >
         arrow_forward_ios
       </span>
@@ -81,6 +83,8 @@ exports[`Carousel should be rendered with only required props and should have de
     >
       <span
         class="Root md mtf-ui-icons xxl"
+        lang="en"
+        translate="no"
       >
         arrow_forward_ios
       </span>

--- a/src/lib/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/lib/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -21,6 +21,8 @@ exports[`DatePicker should be rendered with only required props and should have 
           >
             <span
               class="Root md motifIconsDefault"
+              lang="en"
+              translate="no"
             >
               arrow_back
             </span>
@@ -45,6 +47,8 @@ exports[`DatePicker should be rendered with only required props and should have 
           >
             <span
               class="Root md motifIconsDefault"
+              lang="en"
+              translate="no"
             >
               arrow_forward
             </span>

--- a/src/lib/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/src/lib/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -25,6 +25,8 @@ exports[`DateRangePicker should be rendered with only required props and should 
             </span>
             <span
               class="Root md motifIconsDefault Button-DropdownIcon"
+              lang="en"
+              translate="no"
             >
               arrow_drop_down
             </span>
@@ -36,6 +38,8 @@ exports[`DateRangePicker should be rendered with only required props and should 
         >
           <span
             class="Root md motifIconsDefault icon"
+            lang="en"
+            translate="no"
           >
             calendar_month
           </span>
@@ -52,6 +56,8 @@ exports[`DateRangePicker should be rendered with only required props and should 
         >
           <span
             class="Root md motifIconsDefault icon"
+            lang="en"
+            translate="no"
           >
             calendar_month
           </span>
@@ -374,6 +380,8 @@ exports[`DateRangePicker should be rendered with only required props and should 
             >
               <span
                 class="Root md motifIconsDefault"
+                lang="en"
+                translate="no"
               >
                 arrow_back
               </span>
@@ -662,6 +670,8 @@ exports[`DateRangePicker should be rendered with only required props and should 
             >
               <span
                 class="Root md motifIconsDefault"
+                lang="en"
+                translate="no"
               >
                 arrow_forward
               </span>

--- a/src/lib/components/DateTimePicker/__snapshots__/DateTimePicker.test.tsx.snap
+++ b/src/lib/components/DateTimePicker/__snapshots__/DateTimePicker.test.tsx.snap
@@ -21,6 +21,8 @@ exports[`DatePicker should be rendered with only required props and should have 
           >
             <span
               class="Root md motifIconsDefault"
+              lang="en"
+              translate="no"
             >
               arrow_back
             </span>
@@ -45,6 +47,8 @@ exports[`DatePicker should be rendered with only required props and should have 
           >
             <span
               class="Root md motifIconsDefault"
+              lang="en"
+              translate="no"
             >
               arrow_forward
             </span>

--- a/src/lib/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/lib/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -14,6 +14,8 @@ exports[`Dropdown should be rendered with only required props and should have de
     </span>
     <span
       class="Root md motifIconsDefault Button-DropdownIcon"
+      lang="en"
+      translate="no"
     >
       arrow_drop_down
     </span>

--- a/src/lib/components/Icon/Icon.tsx
+++ b/src/lib/components/Icon/Icon.tsx
@@ -33,7 +33,7 @@ const Icon = (props: PropsWithRefAndChildren<IconProps, HTMLSpanElement>) => {
   ]);
 
   return (
-    <span className={classNames} style={{ ...(color && { color }), ...style }} ref={ref}>
+    <span className={classNames} style={{ ...(color && { color }), ...style }} ref={ref} lang="en" translate="no">
       {iconName || (!isChildMotifIcon && children)}
     </span>
   );

--- a/src/lib/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/lib/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`Icon should be rendered with only required props 1`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     account_circle
   </span>
@@ -14,6 +16,8 @@ exports[`Icon should render all icons in motifIcons set 1`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     motif_ui
   </span>
@@ -24,6 +28,8 @@ exports[`Icon should render all icons in motifIcons set 2`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     accessibility
   </span>
@@ -34,6 +40,8 @@ exports[`Icon should render all icons in motifIcons set 3`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     accessible
   </span>
@@ -44,6 +52,8 @@ exports[`Icon should render all icons in motifIcons set 4`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     accessible_forward
   </span>
@@ -54,6 +64,8 @@ exports[`Icon should render all icons in motifIcons set 5`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     account_balance
   </span>
@@ -64,6 +76,8 @@ exports[`Icon should render all icons in motifIcons set 6`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     account_balance_wallet
   </span>
@@ -74,6 +88,8 @@ exports[`Icon should render all icons in motifIcons set 7`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     account_balance_wallet_outline
   </span>
@@ -84,6 +100,8 @@ exports[`Icon should render all icons in motifIcons set 8`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     account_circle
   </span>
@@ -94,6 +112,8 @@ exports[`Icon should render all icons in motifIcons set 9`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     add
   </span>
@@ -104,6 +124,8 @@ exports[`Icon should render all icons in motifIcons set 10`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     add_box
   </span>
@@ -114,6 +136,8 @@ exports[`Icon should render all icons in motifIcons set 11`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     add_box_outline
   </span>
@@ -124,6 +148,8 @@ exports[`Icon should render all icons in motifIcons set 12`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     add_circle
   </span>
@@ -134,6 +160,8 @@ exports[`Icon should render all icons in motifIcons set 13`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     add_circle_outline
   </span>
@@ -144,6 +172,8 @@ exports[`Icon should render all icons in motifIcons set 14`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     alarm
   </span>
@@ -154,6 +184,8 @@ exports[`Icon should render all icons in motifIcons set 15`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     alarm_add
   </span>
@@ -164,6 +196,8 @@ exports[`Icon should render all icons in motifIcons set 16`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     alternate_email
   </span>
@@ -174,6 +208,8 @@ exports[`Icon should render all icons in motifIcons set 17`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     apartment
   </span>
@@ -184,6 +220,8 @@ exports[`Icon should render all icons in motifIcons set 18`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_back
   </span>
@@ -194,6 +232,8 @@ exports[`Icon should render all icons in motifIcons set 19`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_back_ios_new
   </span>
@@ -204,6 +244,8 @@ exports[`Icon should render all icons in motifIcons set 20`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_downward
   </span>
@@ -214,6 +256,8 @@ exports[`Icon should render all icons in motifIcons set 21`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_drop_down
   </span>
@@ -224,6 +268,8 @@ exports[`Icon should render all icons in motifIcons set 22`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_drop_up
   </span>
@@ -234,6 +280,8 @@ exports[`Icon should render all icons in motifIcons set 23`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_forward
   </span>
@@ -244,6 +292,8 @@ exports[`Icon should render all icons in motifIcons set 24`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_forward_ios
   </span>
@@ -254,6 +304,8 @@ exports[`Icon should render all icons in motifIcons set 25`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_insert
   </span>
@@ -264,6 +316,8 @@ exports[`Icon should render all icons in motifIcons set 26`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_left_alt
   </span>
@@ -274,6 +328,8 @@ exports[`Icon should render all icons in motifIcons set 27`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_right_alt
   </span>
@@ -284,6 +340,8 @@ exports[`Icon should render all icons in motifIcons set 28`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     arrow_upward
   </span>
@@ -294,6 +352,8 @@ exports[`Icon should render all icons in motifIcons set 29`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     article
   </span>
@@ -304,6 +364,8 @@ exports[`Icon should render all icons in motifIcons set 30`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     assignment
   </span>
@@ -314,6 +376,8 @@ exports[`Icon should render all icons in motifIcons set 31`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     assignment_ind
   </span>
@@ -324,6 +388,8 @@ exports[`Icon should render all icons in motifIcons set 32`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     assist_walker
   </span>
@@ -334,6 +400,8 @@ exports[`Icon should render all icons in motifIcons set 33`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     attach_file
   </span>
@@ -344,6 +412,8 @@ exports[`Icon should render all icons in motifIcons set 34`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     autorenew
   </span>
@@ -354,6 +424,8 @@ exports[`Icon should render all icons in motifIcons set 35`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     backspace
   </span>
@@ -364,6 +436,8 @@ exports[`Icon should render all icons in motifIcons set 36`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     backup
   </span>
@@ -374,6 +448,8 @@ exports[`Icon should render all icons in motifIcons set 37`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     balance
   </span>
@@ -384,6 +460,8 @@ exports[`Icon should render all icons in motifIcons set 38`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     bar_chart
   </span>
@@ -394,6 +472,8 @@ exports[`Icon should render all icons in motifIcons set 39`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     blind
   </span>
@@ -404,6 +484,8 @@ exports[`Icon should render all icons in motifIcons set 40`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     block
   </span>
@@ -414,6 +496,8 @@ exports[`Icon should render all icons in motifIcons set 41`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     bookmark
   </span>
@@ -424,6 +508,8 @@ exports[`Icon should render all icons in motifIcons set 42`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     bookmark_manager
   </span>
@@ -434,6 +520,8 @@ exports[`Icon should render all icons in motifIcons set 43`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     bookmark_outline
   </span>
@@ -444,6 +532,8 @@ exports[`Icon should render all icons in motifIcons set 44`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     border_all
   </span>
@@ -454,6 +544,8 @@ exports[`Icon should render all icons in motifIcons set 45`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     cached
   </span>
@@ -464,6 +556,8 @@ exports[`Icon should render all icons in motifIcons set 46`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     calendar_month
   </span>
@@ -474,6 +568,8 @@ exports[`Icon should render all icons in motifIcons set 47`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     calendar_today
   </span>
@@ -484,6 +580,8 @@ exports[`Icon should render all icons in motifIcons set 48`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     call
   </span>
@@ -494,6 +592,8 @@ exports[`Icon should render all icons in motifIcons set 49`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     call_outline
   </span>
@@ -504,6 +604,8 @@ exports[`Icon should render all icons in motifIcons set 50`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     cancel
   </span>
@@ -514,6 +616,8 @@ exports[`Icon should render all icons in motifIcons set 51`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     cancel_outline
   </span>
@@ -524,6 +628,8 @@ exports[`Icon should render all icons in motifIcons set 52`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     cardiology
   </span>
@@ -534,6 +640,8 @@ exports[`Icon should render all icons in motifIcons set 53`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     cases
   </span>
@@ -544,6 +652,8 @@ exports[`Icon should render all icons in motifIcons set 54`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     chat
   </span>
@@ -554,6 +664,8 @@ exports[`Icon should render all icons in motifIcons set 55`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     chat_bubble
   </span>
@@ -564,6 +676,8 @@ exports[`Icon should render all icons in motifIcons set 56`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     check
   </span>
@@ -574,6 +688,8 @@ exports[`Icon should render all icons in motifIcons set 57`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     check_circle
   </span>
@@ -584,6 +700,8 @@ exports[`Icon should render all icons in motifIcons set 58`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     check_circle_outline
   </span>
@@ -594,6 +712,8 @@ exports[`Icon should render all icons in motifIcons set 59`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     checklist
   </span>
@@ -604,6 +724,8 @@ exports[`Icon should render all icons in motifIcons set 60`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     chevron_left
   </span>
@@ -614,6 +736,8 @@ exports[`Icon should render all icons in motifIcons set 61`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     chevron_right
   </span>
@@ -624,6 +748,8 @@ exports[`Icon should render all icons in motifIcons set 62`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     chips
   </span>
@@ -634,6 +760,8 @@ exports[`Icon should render all icons in motifIcons set 63`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     close
   </span>
@@ -644,6 +772,8 @@ exports[`Icon should render all icons in motifIcons set 64`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     cloud_done
   </span>
@@ -654,6 +784,8 @@ exports[`Icon should render all icons in motifIcons set 65`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     cloud_download
   </span>
@@ -664,6 +796,8 @@ exports[`Icon should render all icons in motifIcons set 66`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     collapse_content
   </span>
@@ -674,6 +808,8 @@ exports[`Icon should render all icons in motifIcons set 67`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     collections_bookmark
   </span>
@@ -684,6 +820,8 @@ exports[`Icon should render all icons in motifIcons set 68`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     compare_arrows
   </span>
@@ -694,6 +832,8 @@ exports[`Icon should render all icons in motifIcons set 69`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     contact_page
   </span>
@@ -704,6 +844,8 @@ exports[`Icon should render all icons in motifIcons set 70`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     contact_support
   </span>
@@ -714,6 +856,8 @@ exports[`Icon should render all icons in motifIcons set 71`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     content_copy
   </span>
@@ -724,6 +868,8 @@ exports[`Icon should render all icons in motifIcons set 72`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     content_cut
   </span>
@@ -734,6 +880,8 @@ exports[`Icon should render all icons in motifIcons set 73`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     content_paste
   </span>
@@ -744,6 +892,8 @@ exports[`Icon should render all icons in motifIcons set 74`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     contract
   </span>
@@ -754,6 +904,8 @@ exports[`Icon should render all icons in motifIcons set 75`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     contract_edit
   </span>
@@ -764,6 +916,8 @@ exports[`Icon should render all icons in motifIcons set 76`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     copy_all
   </span>
@@ -774,6 +928,8 @@ exports[`Icon should render all icons in motifIcons set 77`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     create_new_folder
   </span>
@@ -784,6 +940,8 @@ exports[`Icon should render all icons in motifIcons set 78`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     credit_card
   </span>
@@ -794,6 +952,8 @@ exports[`Icon should render all icons in motifIcons set 79`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     crop_free
   </span>
@@ -804,6 +964,8 @@ exports[`Icon should render all icons in motifIcons set 80`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     dashboard
   </span>
@@ -814,6 +976,8 @@ exports[`Icon should render all icons in motifIcons set 81`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     delete
   </span>
@@ -824,6 +988,8 @@ exports[`Icon should render all icons in motifIcons set 82`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     delete_forever
   </span>
@@ -834,6 +1000,8 @@ exports[`Icon should render all icons in motifIcons set 83`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     delete_outline
   </span>
@@ -844,6 +1012,8 @@ exports[`Icon should render all icons in motifIcons set 84`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     density_medium
   </span>
@@ -854,6 +1024,8 @@ exports[`Icon should render all icons in motifIcons set 85`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     description
   </span>
@@ -864,6 +1036,8 @@ exports[`Icon should render all icons in motifIcons set 86`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     device_hub
   </span>
@@ -874,6 +1048,8 @@ exports[`Icon should render all icons in motifIcons set 87`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     device_reset
   </span>
@@ -884,6 +1060,8 @@ exports[`Icon should render all icons in motifIcons set 88`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     devices
   </span>
@@ -894,6 +1072,8 @@ exports[`Icon should render all icons in motifIcons set 89`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     dictionary
   </span>
@@ -904,6 +1084,8 @@ exports[`Icon should render all icons in motifIcons set 90`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     directions_car
   </span>
@@ -914,6 +1096,8 @@ exports[`Icon should render all icons in motifIcons set 91`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     diversity_3
   </span>
@@ -924,6 +1108,8 @@ exports[`Icon should render all icons in motifIcons set 92`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     do_not_disturb_on
   </span>
@@ -934,6 +1120,8 @@ exports[`Icon should render all icons in motifIcons set 93`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     domain
   </span>
@@ -944,6 +1132,8 @@ exports[`Icon should render all icons in motifIcons set 94`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     done_all
   </span>
@@ -954,6 +1144,8 @@ exports[`Icon should render all icons in motifIcons set 95`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     download
   </span>
@@ -964,6 +1156,8 @@ exports[`Icon should render all icons in motifIcons set 96`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     download_2
   </span>
@@ -974,6 +1168,8 @@ exports[`Icon should render all icons in motifIcons set 97`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     downloading
   </span>
@@ -984,6 +1180,8 @@ exports[`Icon should render all icons in motifIcons set 98`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     draft
   </span>
@@ -994,6 +1192,8 @@ exports[`Icon should render all icons in motifIcons set 99`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     drive_folder_upload
   </span>
@@ -1004,6 +1204,8 @@ exports[`Icon should render all icons in motifIcons set 100`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     edit_document
   </span>
@@ -1014,6 +1216,8 @@ exports[`Icon should render all icons in motifIcons set 101`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     emoji_flags
   </span>
@@ -1024,6 +1228,8 @@ exports[`Icon should render all icons in motifIcons set 102`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     emoji_flags_outline
   </span>
@@ -1034,6 +1240,8 @@ exports[`Icon should render all icons in motifIcons set 103`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     encrypted
   </span>
@@ -1044,6 +1252,8 @@ exports[`Icon should render all icons in motifIcons set 104`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     error
   </span>
@@ -1054,6 +1264,8 @@ exports[`Icon should render all icons in motifIcons set 105`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     error_outline
   </span>
@@ -1064,6 +1276,8 @@ exports[`Icon should render all icons in motifIcons set 106`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     event
   </span>
@@ -1074,6 +1288,8 @@ exports[`Icon should render all icons in motifIcons set 107`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     event_available
   </span>
@@ -1084,6 +1300,8 @@ exports[`Icon should render all icons in motifIcons set 108`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     event_busy
   </span>
@@ -1094,6 +1312,8 @@ exports[`Icon should render all icons in motifIcons set 109`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     expand_all
   </span>
@@ -1104,6 +1324,8 @@ exports[`Icon should render all icons in motifIcons set 110`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     expand_content
   </span>
@@ -1114,6 +1336,8 @@ exports[`Icon should render all icons in motifIcons set 111`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     extension
   </span>
@@ -1124,6 +1348,8 @@ exports[`Icon should render all icons in motifIcons set 112`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     external
   </span>
@@ -1134,6 +1360,8 @@ exports[`Icon should render all icons in motifIcons set 113`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     fact_check
   </span>
@@ -1144,6 +1372,8 @@ exports[`Icon should render all icons in motifIcons set 114`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     factory
   </span>
@@ -1154,6 +1384,8 @@ exports[`Icon should render all icons in motifIcons set 115`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     favorite
   </span>
@@ -1164,6 +1396,8 @@ exports[`Icon should render all icons in motifIcons set 116`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     feature_search
   </span>
@@ -1174,6 +1408,8 @@ exports[`Icon should render all icons in motifIcons set 117`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     feed
   </span>
@@ -1184,6 +1420,8 @@ exports[`Icon should render all icons in motifIcons set 118`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     feedback
   </span>
@@ -1194,6 +1432,8 @@ exports[`Icon should render all icons in motifIcons set 119`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     file_copy
   </span>
@@ -1204,6 +1444,8 @@ exports[`Icon should render all icons in motifIcons set 120`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     file_present
   </span>
@@ -1214,6 +1456,8 @@ exports[`Icon should render all icons in motifIcons set 121`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     filter
   </span>
@@ -1224,6 +1468,8 @@ exports[`Icon should render all icons in motifIcons set 122`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     filter_alt
   </span>
@@ -1234,6 +1480,8 @@ exports[`Icon should render all icons in motifIcons set 123`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     filter_alt_off
   </span>
@@ -1244,6 +1492,8 @@ exports[`Icon should render all icons in motifIcons set 124`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     filter_list
   </span>
@@ -1254,6 +1504,8 @@ exports[`Icon should render all icons in motifIcons set 125`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     filter_list_off
   </span>
@@ -1264,6 +1516,8 @@ exports[`Icon should render all icons in motifIcons set 126`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     filter_none
   </span>
@@ -1274,6 +1528,8 @@ exports[`Icon should render all icons in motifIcons set 127`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     finance
   </span>
@@ -1284,6 +1540,8 @@ exports[`Icon should render all icons in motifIcons set 128`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     fingerprint
   </span>
@@ -1294,6 +1552,8 @@ exports[`Icon should render all icons in motifIcons set 129`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     flash_on
   </span>
@@ -1304,6 +1564,8 @@ exports[`Icon should render all icons in motifIcons set 130`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     folder
   </span>
@@ -1314,6 +1576,8 @@ exports[`Icon should render all icons in motifIcons set 131`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     folder_copy
   </span>
@@ -1324,6 +1588,8 @@ exports[`Icon should render all icons in motifIcons set 132`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     folder_managed
   </span>
@@ -1334,6 +1600,8 @@ exports[`Icon should render all icons in motifIcons set 133`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     folder_open
   </span>
@@ -1344,6 +1612,8 @@ exports[`Icon should render all icons in motifIcons set 134`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     folder_outline
   </span>
@@ -1354,6 +1624,8 @@ exports[`Icon should render all icons in motifIcons set 135`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     folder_shared
   </span>
@@ -1364,6 +1636,8 @@ exports[`Icon should render all icons in motifIcons set 136`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     format_quote
   </span>
@@ -1374,6 +1648,8 @@ exports[`Icon should render all icons in motifIcons set 137`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     forum
   </span>
@@ -1384,6 +1660,8 @@ exports[`Icon should render all icons in motifIcons set 138`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     grade
   </span>
@@ -1394,6 +1672,8 @@ exports[`Icon should render all icons in motifIcons set 139`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     group
   </span>
@@ -1404,6 +1684,8 @@ exports[`Icon should render all icons in motifIcons set 140`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     group_add
   </span>
@@ -1414,6 +1696,8 @@ exports[`Icon should render all icons in motifIcons set 141`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     groups
   </span>
@@ -1424,6 +1708,8 @@ exports[`Icon should render all icons in motifIcons set 142`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     handshake
   </span>
@@ -1434,6 +1720,8 @@ exports[`Icon should render all icons in motifIcons set 143`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     handyman
   </span>
@@ -1444,6 +1732,8 @@ exports[`Icon should render all icons in motifIcons set 144`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     heap_snapshot_large
   </span>
@@ -1454,6 +1744,8 @@ exports[`Icon should render all icons in motifIcons set 145`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     hearing
   </span>
@@ -1464,6 +1756,8 @@ exports[`Icon should render all icons in motifIcons set 146`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     hearing_disabled
   </span>
@@ -1474,6 +1768,8 @@ exports[`Icon should render all icons in motifIcons set 147`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     help
   </span>
@@ -1484,6 +1780,8 @@ exports[`Icon should render all icons in motifIcons set 148`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     help_outline
   </span>
@@ -1494,6 +1792,8 @@ exports[`Icon should render all icons in motifIcons set 149`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     home
   </span>
@@ -1504,6 +1804,8 @@ exports[`Icon should render all icons in motifIcons set 150`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     home_outline
   </span>
@@ -1514,6 +1816,8 @@ exports[`Icon should render all icons in motifIcons set 151`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     how_to_reg
   </span>
@@ -1524,6 +1828,8 @@ exports[`Icon should render all icons in motifIcons set 152`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     imagesmode
   </span>
@@ -1534,6 +1840,8 @@ exports[`Icon should render all icons in motifIcons set 153`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     indeterminate_check_box
   </span>
@@ -1544,6 +1852,8 @@ exports[`Icon should render all icons in motifIcons set 154`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     info
   </span>
@@ -1554,6 +1864,8 @@ exports[`Icon should render all icons in motifIcons set 155`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     info_i
   </span>
@@ -1564,6 +1876,8 @@ exports[`Icon should render all icons in motifIcons set 156`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     info_outline
   </span>
@@ -1574,6 +1888,8 @@ exports[`Icon should render all icons in motifIcons set 157`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     insert_chart
   </span>
@@ -1584,6 +1900,8 @@ exports[`Icon should render all icons in motifIcons set 158`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     inventory
   </span>
@@ -1594,6 +1912,8 @@ exports[`Icon should render all icons in motifIcons set 159`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     ios_share
   </span>
@@ -1604,6 +1924,8 @@ exports[`Icon should render all icons in motifIcons set 160`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     keyboard
   </span>
@@ -1614,6 +1936,8 @@ exports[`Icon should render all icons in motifIcons set 161`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     keyboard_alt
   </span>
@@ -1624,6 +1948,8 @@ exports[`Icon should render all icons in motifIcons set 162`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     keyboard_arrow_down
   </span>
@@ -1634,6 +1960,8 @@ exports[`Icon should render all icons in motifIcons set 163`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     keyboard_arrow_up
   </span>
@@ -1644,6 +1972,8 @@ exports[`Icon should render all icons in motifIcons set 164`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     keyboard_voice
   </span>
@@ -1654,6 +1984,8 @@ exports[`Icon should render all icons in motifIcons set 165`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     label
   </span>
@@ -1664,6 +1996,8 @@ exports[`Icon should render all icons in motifIcons set 166`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     label_outline
   </span>
@@ -1674,6 +2008,8 @@ exports[`Icon should render all icons in motifIcons set 167`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     language
   </span>
@@ -1684,6 +2020,8 @@ exports[`Icon should render all icons in motifIcons set 168`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     library_books
   </span>
@@ -1694,6 +2032,8 @@ exports[`Icon should render all icons in motifIcons set 169`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     link
   </span>
@@ -1704,6 +2044,8 @@ exports[`Icon should render all icons in motifIcons set 170`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     link_off
   </span>
@@ -1714,6 +2056,8 @@ exports[`Icon should render all icons in motifIcons set 171`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     list_alt
   </span>
@@ -1724,6 +2068,8 @@ exports[`Icon should render all icons in motifIcons set 172`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     lists
   </span>
@@ -1734,6 +2080,8 @@ exports[`Icon should render all icons in motifIcons set 173`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     local_library
   </span>
@@ -1744,6 +2092,8 @@ exports[`Icon should render all icons in motifIcons set 174`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     local_mall
   </span>
@@ -1754,6 +2104,8 @@ exports[`Icon should render all icons in motifIcons set 175`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     location_off
   </span>
@@ -1764,6 +2116,8 @@ exports[`Icon should render all icons in motifIcons set 176`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     location_on
   </span>
@@ -1774,6 +2128,8 @@ exports[`Icon should render all icons in motifIcons set 177`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     location_on_outline
   </span>
@@ -1784,6 +2140,8 @@ exports[`Icon should render all icons in motifIcons set 178`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     lock
   </span>
@@ -1794,6 +2152,8 @@ exports[`Icon should render all icons in motifIcons set 179`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     lock_open
   </span>
@@ -1804,6 +2164,8 @@ exports[`Icon should render all icons in motifIcons set 180`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     logout
   </span>
@@ -1814,6 +2176,8 @@ exports[`Icon should render all icons in motifIcons set 181`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     mail
   </span>
@@ -1824,6 +2188,8 @@ exports[`Icon should render all icons in motifIcons set 182`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     mail_outline
   </span>
@@ -1834,6 +2200,8 @@ exports[`Icon should render all icons in motifIcons set 183`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     map
   </span>
@@ -1844,6 +2212,8 @@ exports[`Icon should render all icons in motifIcons set 184`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     mode_cool
   </span>
@@ -1854,6 +2224,8 @@ exports[`Icon should render all icons in motifIcons set 185`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     mode_heat
   </span>
@@ -1864,6 +2236,8 @@ exports[`Icon should render all icons in motifIcons set 186`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     more_horiz
   </span>
@@ -1874,6 +2248,8 @@ exports[`Icon should render all icons in motifIcons set 187`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     more_time
   </span>
@@ -1884,6 +2260,8 @@ exports[`Icon should render all icons in motifIcons set 188`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     more_vert
   </span>
@@ -1894,6 +2272,8 @@ exports[`Icon should render all icons in motifIcons set 189`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     moving
   </span>
@@ -1904,6 +2284,8 @@ exports[`Icon should render all icons in motifIcons set 190`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     nature
   </span>
@@ -1914,6 +2296,8 @@ exports[`Icon should render all icons in motifIcons set 191`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     near_me
   </span>
@@ -1924,6 +2308,8 @@ exports[`Icon should render all icons in motifIcons set 192`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     nest_eco_leaf
   </span>
@@ -1934,6 +2320,8 @@ exports[`Icon should render all icons in motifIcons set 193`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     note
   </span>
@@ -1944,6 +2332,8 @@ exports[`Icon should render all icons in motifIcons set 194`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     note_add
   </span>
@@ -1954,6 +2344,8 @@ exports[`Icon should render all icons in motifIcons set 195`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     notifications
   </span>
@@ -1964,6 +2356,8 @@ exports[`Icon should render all icons in motifIcons set 196`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     notifications_active
   </span>
@@ -1974,6 +2368,8 @@ exports[`Icon should render all icons in motifIcons set 197`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     notifications_off
   </span>
@@ -1984,6 +2380,8 @@ exports[`Icon should render all icons in motifIcons set 198`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     palette
   </span>
@@ -1994,6 +2392,8 @@ exports[`Icon should render all icons in motifIcons set 199`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     passkey
   </span>
@@ -2004,6 +2404,8 @@ exports[`Icon should render all icons in motifIcons set 200`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     payments
   </span>
@@ -2014,6 +2416,8 @@ exports[`Icon should render all icons in motifIcons set 201`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     person
   </span>
@@ -2024,6 +2428,8 @@ exports[`Icon should render all icons in motifIcons set 202`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     person_outline
   </span>
@@ -2034,6 +2440,8 @@ exports[`Icon should render all icons in motifIcons set 203`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     phone_iphone
   </span>
@@ -2044,6 +2452,8 @@ exports[`Icon should render all icons in motifIcons set 204`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     photo
   </span>
@@ -2054,6 +2464,8 @@ exports[`Icon should render all icons in motifIcons set 205`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     photo_camera
   </span>
@@ -2064,6 +2476,8 @@ exports[`Icon should render all icons in motifIcons set 206`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     photo_camera_outline
   </span>
@@ -2074,6 +2488,8 @@ exports[`Icon should render all icons in motifIcons set 207`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     picture_as_pdf
   </span>
@@ -2084,6 +2500,8 @@ exports[`Icon should render all icons in motifIcons set 208`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     pie_chart
   </span>
@@ -2094,6 +2512,8 @@ exports[`Icon should render all icons in motifIcons set 209`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     plagiarism
   </span>
@@ -2104,6 +2524,8 @@ exports[`Icon should render all icons in motifIcons set 210`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     podcasts
   </span>
@@ -2114,6 +2536,8 @@ exports[`Icon should render all icons in motifIcons set 211`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     priority_high
   </span>
@@ -2124,6 +2548,8 @@ exports[`Icon should render all icons in motifIcons set 212`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     privacy_tip
   </span>
@@ -2134,6 +2560,8 @@ exports[`Icon should render all icons in motifIcons set 213`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     prompt_suggestion
   </span>
@@ -2144,6 +2572,8 @@ exports[`Icon should render all icons in motifIcons set 214`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     psychiatry
   </span>
@@ -2154,6 +2584,8 @@ exports[`Icon should render all icons in motifIcons set 215`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     push_pin
   </span>
@@ -2164,6 +2596,8 @@ exports[`Icon should render all icons in motifIcons set 216`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     push_pin_outline
   </span>
@@ -2174,6 +2608,8 @@ exports[`Icon should render all icons in motifIcons set 217`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     question_mark
   </span>
@@ -2184,6 +2620,8 @@ exports[`Icon should render all icons in motifIcons set 218`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     receipt
   </span>
@@ -2194,6 +2632,8 @@ exports[`Icon should render all icons in motifIcons set 219`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     receipt_long
   </span>
@@ -2204,6 +2644,8 @@ exports[`Icon should render all icons in motifIcons set 220`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     remove
   </span>
@@ -2214,6 +2656,8 @@ exports[`Icon should render all icons in motifIcons set 221`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     reply
   </span>
@@ -2224,6 +2668,8 @@ exports[`Icon should render all icons in motifIcons set 222`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     schedule
   </span>
@@ -2234,6 +2680,8 @@ exports[`Icon should render all icons in motifIcons set 223`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     schedule_outline
   </span>
@@ -2244,6 +2692,8 @@ exports[`Icon should render all icons in motifIcons set 224`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     school
   </span>
@@ -2254,6 +2704,8 @@ exports[`Icon should render all icons in motifIcons set 225`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     search
   </span>
@@ -2264,6 +2716,8 @@ exports[`Icon should render all icons in motifIcons set 226`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     send
   </span>
@@ -2274,6 +2728,8 @@ exports[`Icon should render all icons in motifIcons set 227`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     send_outline
   </span>
@@ -2284,6 +2740,8 @@ exports[`Icon should render all icons in motifIcons set 228`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     sentiment_dissatisfied
   </span>
@@ -2294,6 +2752,8 @@ exports[`Icon should render all icons in motifIcons set 229`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     sentiment_satisfied
   </span>
@@ -2304,6 +2764,8 @@ exports[`Icon should render all icons in motifIcons set 230`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     settings
   </span>
@@ -2314,6 +2776,8 @@ exports[`Icon should render all icons in motifIcons set 231`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     settings_outline
   </span>
@@ -2324,6 +2788,8 @@ exports[`Icon should render all icons in motifIcons set 232`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     share
   </span>
@@ -2334,6 +2800,8 @@ exports[`Icon should render all icons in motifIcons set 233`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     shield
   </span>
@@ -2344,6 +2812,8 @@ exports[`Icon should render all icons in motifIcons set 234`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     shield_lock
   </span>
@@ -2354,6 +2824,8 @@ exports[`Icon should render all icons in motifIcons set 235`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     signpost
   </span>
@@ -2364,6 +2836,8 @@ exports[`Icon should render all icons in motifIcons set 236`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     sim_card
   </span>
@@ -2374,6 +2848,8 @@ exports[`Icon should render all icons in motifIcons set 237`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     sim_card_outline
   </span>
@@ -2384,6 +2860,8 @@ exports[`Icon should render all icons in motifIcons set 238`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     speed
   </span>
@@ -2394,6 +2872,8 @@ exports[`Icon should render all icons in motifIcons set 239`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     stethoscope
   </span>
@@ -2404,6 +2884,8 @@ exports[`Icon should render all icons in motifIcons set 240`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     store
   </span>
@@ -2414,6 +2896,8 @@ exports[`Icon should render all icons in motifIcons set 241`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     supervisor_account
   </span>
@@ -2424,6 +2908,8 @@ exports[`Icon should render all icons in motifIcons set 242`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     table_rows
   </span>
@@ -2434,6 +2920,8 @@ exports[`Icon should render all icons in motifIcons set 243`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     task
   </span>
@@ -2444,6 +2932,8 @@ exports[`Icon should render all icons in motifIcons set 244`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     task_alt
   </span>
@@ -2454,6 +2944,8 @@ exports[`Icon should render all icons in motifIcons set 245`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     thumb_down
   </span>
@@ -2464,6 +2956,8 @@ exports[`Icon should render all icons in motifIcons set 246`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     thumb_up
   </span>
@@ -2474,6 +2968,8 @@ exports[`Icon should render all icons in motifIcons set 247`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     topic
   </span>
@@ -2484,6 +2980,8 @@ exports[`Icon should render all icons in motifIcons set 248`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     touch_app
   </span>
@@ -2494,6 +2992,8 @@ exports[`Icon should render all icons in motifIcons set 249`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     trophy
   </span>
@@ -2504,6 +3004,8 @@ exports[`Icon should render all icons in motifIcons set 250`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     undo
   </span>
@@ -2514,6 +3016,8 @@ exports[`Icon should render all icons in motifIcons set 251`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     upload
   </span>
@@ -2524,6 +3028,8 @@ exports[`Icon should render all icons in motifIcons set 252`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     upload_2
   </span>
@@ -2534,6 +3040,8 @@ exports[`Icon should render all icons in motifIcons set 253`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     upload_file
   </span>
@@ -2544,6 +3052,8 @@ exports[`Icon should render all icons in motifIcons set 254`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     verified_user
   </span>
@@ -2554,6 +3064,8 @@ exports[`Icon should render all icons in motifIcons set 255`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     videocam
   </span>
@@ -2564,6 +3076,8 @@ exports[`Icon should render all icons in motifIcons set 256`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     videocam_off
   </span>
@@ -2574,6 +3088,8 @@ exports[`Icon should render all icons in motifIcons set 257`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     visibility
   </span>
@@ -2584,6 +3100,8 @@ exports[`Icon should render all icons in motifIcons set 258`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     visibility_off
   </span>
@@ -2594,6 +3112,8 @@ exports[`Icon should render all icons in motifIcons set 259`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     volume_off
   </span>
@@ -2604,6 +3124,8 @@ exports[`Icon should render all icons in motifIcons set 260`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     volume_up
   </span>
@@ -2614,6 +3136,8 @@ exports[`Icon should render all icons in motifIcons set 261`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     volunteer_activism
   </span>
@@ -2624,6 +3148,8 @@ exports[`Icon should render all icons in motifIcons set 262`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     vpn_key
   </span>
@@ -2634,6 +3160,8 @@ exports[`Icon should render all icons in motifIcons set 263`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     vpn_key_off
   </span>
@@ -2644,6 +3172,8 @@ exports[`Icon should render all icons in motifIcons set 264`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     warning
   </span>
@@ -2654,6 +3184,8 @@ exports[`Icon should render all icons in motifIcons set 265`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     warning_outline
   </span>
@@ -2664,6 +3196,8 @@ exports[`Icon should render all icons in motifIcons set 266`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     water_drop
   </span>
@@ -2674,6 +3208,8 @@ exports[`Icon should render all icons in motifIcons set 267`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     waves
   </span>
@@ -2684,6 +3220,8 @@ exports[`Icon should render all icons in motifIcons set 268`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     wb_sunny
   </span>
@@ -2694,6 +3232,8 @@ exports[`Icon should render all icons in motifIcons set 269`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     work
   </span>
@@ -2704,6 +3244,8 @@ exports[`Icon should render all icons in motifIcons set 270`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     work_outline
   </span>
@@ -2714,6 +3256,8 @@ exports[`Icon should render all icons in motifIcons set 271`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     zoom_in
   </span>
@@ -2724,6 +3268,8 @@ exports[`Icon should render all icons in motifIcons set 272`] = `
 <div>
   <span
     class="Root md mtf-ui-icons"
+    lang="en"
+    translate="no"
   >
     zoom_out
   </span>

--- a/src/lib/components/IconButton/__snapshots__/IconButton.test.tsx.snap
+++ b/src/lib/components/IconButton/__snapshots__/IconButton.test.tsx.snap
@@ -9,6 +9,8 @@ exports[`IconButton should be rendered with only required props 1`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       account_circle
     </span>
@@ -25,6 +27,8 @@ exports[`IconButton should render all icons in motifIcons set 1`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       motif_ui
     </span>
@@ -41,6 +45,8 @@ exports[`IconButton should render all icons in motifIcons set 2`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       accessibility
     </span>
@@ -57,6 +63,8 @@ exports[`IconButton should render all icons in motifIcons set 3`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       accessible
     </span>
@@ -73,6 +81,8 @@ exports[`IconButton should render all icons in motifIcons set 4`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       accessible_forward
     </span>
@@ -89,6 +99,8 @@ exports[`IconButton should render all icons in motifIcons set 5`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       account_balance
     </span>
@@ -105,6 +117,8 @@ exports[`IconButton should render all icons in motifIcons set 6`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       account_balance_wallet
     </span>
@@ -121,6 +135,8 @@ exports[`IconButton should render all icons in motifIcons set 7`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       account_balance_wallet_outline
     </span>
@@ -137,6 +153,8 @@ exports[`IconButton should render all icons in motifIcons set 8`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       account_circle
     </span>
@@ -153,6 +171,8 @@ exports[`IconButton should render all icons in motifIcons set 9`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       add
     </span>
@@ -169,6 +189,8 @@ exports[`IconButton should render all icons in motifIcons set 10`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       add_box
     </span>
@@ -185,6 +207,8 @@ exports[`IconButton should render all icons in motifIcons set 11`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       add_box_outline
     </span>
@@ -201,6 +225,8 @@ exports[`IconButton should render all icons in motifIcons set 12`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       add_circle
     </span>
@@ -217,6 +243,8 @@ exports[`IconButton should render all icons in motifIcons set 13`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       add_circle_outline
     </span>
@@ -233,6 +261,8 @@ exports[`IconButton should render all icons in motifIcons set 14`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       alarm
     </span>
@@ -249,6 +279,8 @@ exports[`IconButton should render all icons in motifIcons set 15`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       alarm_add
     </span>
@@ -265,6 +297,8 @@ exports[`IconButton should render all icons in motifIcons set 16`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       alternate_email
     </span>
@@ -281,6 +315,8 @@ exports[`IconButton should render all icons in motifIcons set 17`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       apartment
     </span>
@@ -297,6 +333,8 @@ exports[`IconButton should render all icons in motifIcons set 18`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_back
     </span>
@@ -313,6 +351,8 @@ exports[`IconButton should render all icons in motifIcons set 19`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_back_ios_new
     </span>
@@ -329,6 +369,8 @@ exports[`IconButton should render all icons in motifIcons set 20`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_downward
     </span>
@@ -345,6 +387,8 @@ exports[`IconButton should render all icons in motifIcons set 21`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_drop_down
     </span>
@@ -361,6 +405,8 @@ exports[`IconButton should render all icons in motifIcons set 22`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_drop_up
     </span>
@@ -377,6 +423,8 @@ exports[`IconButton should render all icons in motifIcons set 23`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_forward
     </span>
@@ -393,6 +441,8 @@ exports[`IconButton should render all icons in motifIcons set 24`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_forward_ios
     </span>
@@ -409,6 +459,8 @@ exports[`IconButton should render all icons in motifIcons set 25`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_insert
     </span>
@@ -425,6 +477,8 @@ exports[`IconButton should render all icons in motifIcons set 26`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_left_alt
     </span>
@@ -441,6 +495,8 @@ exports[`IconButton should render all icons in motifIcons set 27`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_right_alt
     </span>
@@ -457,6 +513,8 @@ exports[`IconButton should render all icons in motifIcons set 28`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       arrow_upward
     </span>
@@ -473,6 +531,8 @@ exports[`IconButton should render all icons in motifIcons set 29`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       article
     </span>
@@ -489,6 +549,8 @@ exports[`IconButton should render all icons in motifIcons set 30`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       assignment
     </span>
@@ -505,6 +567,8 @@ exports[`IconButton should render all icons in motifIcons set 31`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       assignment_ind
     </span>
@@ -521,6 +585,8 @@ exports[`IconButton should render all icons in motifIcons set 32`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       assist_walker
     </span>
@@ -537,6 +603,8 @@ exports[`IconButton should render all icons in motifIcons set 33`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       attach_file
     </span>
@@ -553,6 +621,8 @@ exports[`IconButton should render all icons in motifIcons set 34`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       autorenew
     </span>
@@ -569,6 +639,8 @@ exports[`IconButton should render all icons in motifIcons set 35`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       backspace
     </span>
@@ -585,6 +657,8 @@ exports[`IconButton should render all icons in motifIcons set 36`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       backup
     </span>
@@ -601,6 +675,8 @@ exports[`IconButton should render all icons in motifIcons set 37`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       balance
     </span>
@@ -617,6 +693,8 @@ exports[`IconButton should render all icons in motifIcons set 38`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       bar_chart
     </span>
@@ -633,6 +711,8 @@ exports[`IconButton should render all icons in motifIcons set 39`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       blind
     </span>
@@ -649,6 +729,8 @@ exports[`IconButton should render all icons in motifIcons set 40`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       block
     </span>
@@ -665,6 +747,8 @@ exports[`IconButton should render all icons in motifIcons set 41`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       bookmark
     </span>
@@ -681,6 +765,8 @@ exports[`IconButton should render all icons in motifIcons set 42`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       bookmark_manager
     </span>
@@ -697,6 +783,8 @@ exports[`IconButton should render all icons in motifIcons set 43`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       bookmark_outline
     </span>
@@ -713,6 +801,8 @@ exports[`IconButton should render all icons in motifIcons set 44`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       border_all
     </span>
@@ -729,6 +819,8 @@ exports[`IconButton should render all icons in motifIcons set 45`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       cached
     </span>
@@ -745,6 +837,8 @@ exports[`IconButton should render all icons in motifIcons set 46`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       calendar_month
     </span>
@@ -761,6 +855,8 @@ exports[`IconButton should render all icons in motifIcons set 47`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       calendar_today
     </span>
@@ -777,6 +873,8 @@ exports[`IconButton should render all icons in motifIcons set 48`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       call
     </span>
@@ -793,6 +891,8 @@ exports[`IconButton should render all icons in motifIcons set 49`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       call_outline
     </span>
@@ -809,6 +909,8 @@ exports[`IconButton should render all icons in motifIcons set 50`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       cancel
     </span>
@@ -825,6 +927,8 @@ exports[`IconButton should render all icons in motifIcons set 51`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       cancel_outline
     </span>
@@ -841,6 +945,8 @@ exports[`IconButton should render all icons in motifIcons set 52`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       cardiology
     </span>
@@ -857,6 +963,8 @@ exports[`IconButton should render all icons in motifIcons set 53`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       cases
     </span>
@@ -873,6 +981,8 @@ exports[`IconButton should render all icons in motifIcons set 54`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       chat
     </span>
@@ -889,6 +999,8 @@ exports[`IconButton should render all icons in motifIcons set 55`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       chat_bubble
     </span>
@@ -905,6 +1017,8 @@ exports[`IconButton should render all icons in motifIcons set 56`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       check
     </span>
@@ -921,6 +1035,8 @@ exports[`IconButton should render all icons in motifIcons set 57`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       check_circle
     </span>
@@ -937,6 +1053,8 @@ exports[`IconButton should render all icons in motifIcons set 58`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       check_circle_outline
     </span>
@@ -953,6 +1071,8 @@ exports[`IconButton should render all icons in motifIcons set 59`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       checklist
     </span>
@@ -969,6 +1089,8 @@ exports[`IconButton should render all icons in motifIcons set 60`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       chevron_left
     </span>
@@ -985,6 +1107,8 @@ exports[`IconButton should render all icons in motifIcons set 61`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       chevron_right
     </span>
@@ -1001,6 +1125,8 @@ exports[`IconButton should render all icons in motifIcons set 62`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       chips
     </span>
@@ -1017,6 +1143,8 @@ exports[`IconButton should render all icons in motifIcons set 63`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       close
     </span>
@@ -1033,6 +1161,8 @@ exports[`IconButton should render all icons in motifIcons set 64`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       cloud_done
     </span>
@@ -1049,6 +1179,8 @@ exports[`IconButton should render all icons in motifIcons set 65`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       cloud_download
     </span>
@@ -1065,6 +1197,8 @@ exports[`IconButton should render all icons in motifIcons set 66`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       collapse_content
     </span>
@@ -1081,6 +1215,8 @@ exports[`IconButton should render all icons in motifIcons set 67`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       collections_bookmark
     </span>
@@ -1097,6 +1233,8 @@ exports[`IconButton should render all icons in motifIcons set 68`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       compare_arrows
     </span>
@@ -1113,6 +1251,8 @@ exports[`IconButton should render all icons in motifIcons set 69`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       contact_page
     </span>
@@ -1129,6 +1269,8 @@ exports[`IconButton should render all icons in motifIcons set 70`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       contact_support
     </span>
@@ -1145,6 +1287,8 @@ exports[`IconButton should render all icons in motifIcons set 71`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       content_copy
     </span>
@@ -1161,6 +1305,8 @@ exports[`IconButton should render all icons in motifIcons set 72`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       content_cut
     </span>
@@ -1177,6 +1323,8 @@ exports[`IconButton should render all icons in motifIcons set 73`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       content_paste
     </span>
@@ -1193,6 +1341,8 @@ exports[`IconButton should render all icons in motifIcons set 74`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       contract
     </span>
@@ -1209,6 +1359,8 @@ exports[`IconButton should render all icons in motifIcons set 75`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       contract_edit
     </span>
@@ -1225,6 +1377,8 @@ exports[`IconButton should render all icons in motifIcons set 76`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       copy_all
     </span>
@@ -1241,6 +1395,8 @@ exports[`IconButton should render all icons in motifIcons set 77`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       create_new_folder
     </span>
@@ -1257,6 +1413,8 @@ exports[`IconButton should render all icons in motifIcons set 78`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       credit_card
     </span>
@@ -1273,6 +1431,8 @@ exports[`IconButton should render all icons in motifIcons set 79`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       crop_free
     </span>
@@ -1289,6 +1449,8 @@ exports[`IconButton should render all icons in motifIcons set 80`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       dashboard
     </span>
@@ -1305,6 +1467,8 @@ exports[`IconButton should render all icons in motifIcons set 81`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       delete
     </span>
@@ -1321,6 +1485,8 @@ exports[`IconButton should render all icons in motifIcons set 82`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       delete_forever
     </span>
@@ -1337,6 +1503,8 @@ exports[`IconButton should render all icons in motifIcons set 83`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       delete_outline
     </span>
@@ -1353,6 +1521,8 @@ exports[`IconButton should render all icons in motifIcons set 84`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       density_medium
     </span>
@@ -1369,6 +1539,8 @@ exports[`IconButton should render all icons in motifIcons set 85`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       description
     </span>
@@ -1385,6 +1557,8 @@ exports[`IconButton should render all icons in motifIcons set 86`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       device_hub
     </span>
@@ -1401,6 +1575,8 @@ exports[`IconButton should render all icons in motifIcons set 87`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       device_reset
     </span>
@@ -1417,6 +1593,8 @@ exports[`IconButton should render all icons in motifIcons set 88`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       devices
     </span>
@@ -1433,6 +1611,8 @@ exports[`IconButton should render all icons in motifIcons set 89`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       dictionary
     </span>
@@ -1449,6 +1629,8 @@ exports[`IconButton should render all icons in motifIcons set 90`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       directions_car
     </span>
@@ -1465,6 +1647,8 @@ exports[`IconButton should render all icons in motifIcons set 91`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       diversity_3
     </span>
@@ -1481,6 +1665,8 @@ exports[`IconButton should render all icons in motifIcons set 92`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       do_not_disturb_on
     </span>
@@ -1497,6 +1683,8 @@ exports[`IconButton should render all icons in motifIcons set 93`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       domain
     </span>
@@ -1513,6 +1701,8 @@ exports[`IconButton should render all icons in motifIcons set 94`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       done_all
     </span>
@@ -1529,6 +1719,8 @@ exports[`IconButton should render all icons in motifIcons set 95`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       download
     </span>
@@ -1545,6 +1737,8 @@ exports[`IconButton should render all icons in motifIcons set 96`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       download_2
     </span>
@@ -1561,6 +1755,8 @@ exports[`IconButton should render all icons in motifIcons set 97`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       downloading
     </span>
@@ -1577,6 +1773,8 @@ exports[`IconButton should render all icons in motifIcons set 98`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       draft
     </span>
@@ -1593,6 +1791,8 @@ exports[`IconButton should render all icons in motifIcons set 99`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       drive_folder_upload
     </span>
@@ -1609,6 +1809,8 @@ exports[`IconButton should render all icons in motifIcons set 100`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       edit_document
     </span>
@@ -1625,6 +1827,8 @@ exports[`IconButton should render all icons in motifIcons set 101`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       emoji_flags
     </span>
@@ -1641,6 +1845,8 @@ exports[`IconButton should render all icons in motifIcons set 102`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       emoji_flags_outline
     </span>
@@ -1657,6 +1863,8 @@ exports[`IconButton should render all icons in motifIcons set 103`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       encrypted
     </span>
@@ -1673,6 +1881,8 @@ exports[`IconButton should render all icons in motifIcons set 104`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       error
     </span>
@@ -1689,6 +1899,8 @@ exports[`IconButton should render all icons in motifIcons set 105`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       error_outline
     </span>
@@ -1705,6 +1917,8 @@ exports[`IconButton should render all icons in motifIcons set 106`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       event
     </span>
@@ -1721,6 +1935,8 @@ exports[`IconButton should render all icons in motifIcons set 107`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       event_available
     </span>
@@ -1737,6 +1953,8 @@ exports[`IconButton should render all icons in motifIcons set 108`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       event_busy
     </span>
@@ -1753,6 +1971,8 @@ exports[`IconButton should render all icons in motifIcons set 109`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       expand_all
     </span>
@@ -1769,6 +1989,8 @@ exports[`IconButton should render all icons in motifIcons set 110`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       expand_content
     </span>
@@ -1785,6 +2007,8 @@ exports[`IconButton should render all icons in motifIcons set 111`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       extension
     </span>
@@ -1801,6 +2025,8 @@ exports[`IconButton should render all icons in motifIcons set 112`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       external
     </span>
@@ -1817,6 +2043,8 @@ exports[`IconButton should render all icons in motifIcons set 113`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       fact_check
     </span>
@@ -1833,6 +2061,8 @@ exports[`IconButton should render all icons in motifIcons set 114`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       factory
     </span>
@@ -1849,6 +2079,8 @@ exports[`IconButton should render all icons in motifIcons set 115`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       favorite
     </span>
@@ -1865,6 +2097,8 @@ exports[`IconButton should render all icons in motifIcons set 116`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       feature_search
     </span>
@@ -1881,6 +2115,8 @@ exports[`IconButton should render all icons in motifIcons set 117`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       feed
     </span>
@@ -1897,6 +2133,8 @@ exports[`IconButton should render all icons in motifIcons set 118`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       feedback
     </span>
@@ -1913,6 +2151,8 @@ exports[`IconButton should render all icons in motifIcons set 119`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       file_copy
     </span>
@@ -1929,6 +2169,8 @@ exports[`IconButton should render all icons in motifIcons set 120`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       file_present
     </span>
@@ -1945,6 +2187,8 @@ exports[`IconButton should render all icons in motifIcons set 121`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       filter
     </span>
@@ -1961,6 +2205,8 @@ exports[`IconButton should render all icons in motifIcons set 122`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       filter_alt
     </span>
@@ -1977,6 +2223,8 @@ exports[`IconButton should render all icons in motifIcons set 123`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       filter_alt_off
     </span>
@@ -1993,6 +2241,8 @@ exports[`IconButton should render all icons in motifIcons set 124`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       filter_list
     </span>
@@ -2009,6 +2259,8 @@ exports[`IconButton should render all icons in motifIcons set 125`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       filter_list_off
     </span>
@@ -2025,6 +2277,8 @@ exports[`IconButton should render all icons in motifIcons set 126`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       filter_none
     </span>
@@ -2041,6 +2295,8 @@ exports[`IconButton should render all icons in motifIcons set 127`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       finance
     </span>
@@ -2057,6 +2313,8 @@ exports[`IconButton should render all icons in motifIcons set 128`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       fingerprint
     </span>
@@ -2073,6 +2331,8 @@ exports[`IconButton should render all icons in motifIcons set 129`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       flash_on
     </span>
@@ -2089,6 +2349,8 @@ exports[`IconButton should render all icons in motifIcons set 130`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       folder
     </span>
@@ -2105,6 +2367,8 @@ exports[`IconButton should render all icons in motifIcons set 131`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       folder_copy
     </span>
@@ -2121,6 +2385,8 @@ exports[`IconButton should render all icons in motifIcons set 132`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       folder_managed
     </span>
@@ -2137,6 +2403,8 @@ exports[`IconButton should render all icons in motifIcons set 133`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       folder_open
     </span>
@@ -2153,6 +2421,8 @@ exports[`IconButton should render all icons in motifIcons set 134`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       folder_outline
     </span>
@@ -2169,6 +2439,8 @@ exports[`IconButton should render all icons in motifIcons set 135`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       folder_shared
     </span>
@@ -2185,6 +2457,8 @@ exports[`IconButton should render all icons in motifIcons set 136`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       format_quote
     </span>
@@ -2201,6 +2475,8 @@ exports[`IconButton should render all icons in motifIcons set 137`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       forum
     </span>
@@ -2217,6 +2493,8 @@ exports[`IconButton should render all icons in motifIcons set 138`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       grade
     </span>
@@ -2233,6 +2511,8 @@ exports[`IconButton should render all icons in motifIcons set 139`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       group
     </span>
@@ -2249,6 +2529,8 @@ exports[`IconButton should render all icons in motifIcons set 140`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       group_add
     </span>
@@ -2265,6 +2547,8 @@ exports[`IconButton should render all icons in motifIcons set 141`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       groups
     </span>
@@ -2281,6 +2565,8 @@ exports[`IconButton should render all icons in motifIcons set 142`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       handshake
     </span>
@@ -2297,6 +2583,8 @@ exports[`IconButton should render all icons in motifIcons set 143`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       handyman
     </span>
@@ -2313,6 +2601,8 @@ exports[`IconButton should render all icons in motifIcons set 144`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       heap_snapshot_large
     </span>
@@ -2329,6 +2619,8 @@ exports[`IconButton should render all icons in motifIcons set 145`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       hearing
     </span>
@@ -2345,6 +2637,8 @@ exports[`IconButton should render all icons in motifIcons set 146`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       hearing_disabled
     </span>
@@ -2361,6 +2655,8 @@ exports[`IconButton should render all icons in motifIcons set 147`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       help
     </span>
@@ -2377,6 +2673,8 @@ exports[`IconButton should render all icons in motifIcons set 148`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       help_outline
     </span>
@@ -2393,6 +2691,8 @@ exports[`IconButton should render all icons in motifIcons set 149`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       home
     </span>
@@ -2409,6 +2709,8 @@ exports[`IconButton should render all icons in motifIcons set 150`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       home_outline
     </span>
@@ -2425,6 +2727,8 @@ exports[`IconButton should render all icons in motifIcons set 151`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       how_to_reg
     </span>
@@ -2441,6 +2745,8 @@ exports[`IconButton should render all icons in motifIcons set 152`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       imagesmode
     </span>
@@ -2457,6 +2763,8 @@ exports[`IconButton should render all icons in motifIcons set 153`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       indeterminate_check_box
     </span>
@@ -2473,6 +2781,8 @@ exports[`IconButton should render all icons in motifIcons set 154`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       info
     </span>
@@ -2489,6 +2799,8 @@ exports[`IconButton should render all icons in motifIcons set 155`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       info_i
     </span>
@@ -2505,6 +2817,8 @@ exports[`IconButton should render all icons in motifIcons set 156`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       info_outline
     </span>
@@ -2521,6 +2835,8 @@ exports[`IconButton should render all icons in motifIcons set 157`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       insert_chart
     </span>
@@ -2537,6 +2853,8 @@ exports[`IconButton should render all icons in motifIcons set 158`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       inventory
     </span>
@@ -2553,6 +2871,8 @@ exports[`IconButton should render all icons in motifIcons set 159`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       ios_share
     </span>
@@ -2569,6 +2889,8 @@ exports[`IconButton should render all icons in motifIcons set 160`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       keyboard
     </span>
@@ -2585,6 +2907,8 @@ exports[`IconButton should render all icons in motifIcons set 161`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       keyboard_alt
     </span>
@@ -2601,6 +2925,8 @@ exports[`IconButton should render all icons in motifIcons set 162`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       keyboard_arrow_down
     </span>
@@ -2617,6 +2943,8 @@ exports[`IconButton should render all icons in motifIcons set 163`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       keyboard_arrow_up
     </span>
@@ -2633,6 +2961,8 @@ exports[`IconButton should render all icons in motifIcons set 164`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       keyboard_voice
     </span>
@@ -2649,6 +2979,8 @@ exports[`IconButton should render all icons in motifIcons set 165`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       label
     </span>
@@ -2665,6 +2997,8 @@ exports[`IconButton should render all icons in motifIcons set 166`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       label_outline
     </span>
@@ -2681,6 +3015,8 @@ exports[`IconButton should render all icons in motifIcons set 167`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       language
     </span>
@@ -2697,6 +3033,8 @@ exports[`IconButton should render all icons in motifIcons set 168`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       library_books
     </span>
@@ -2713,6 +3051,8 @@ exports[`IconButton should render all icons in motifIcons set 169`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       link
     </span>
@@ -2729,6 +3069,8 @@ exports[`IconButton should render all icons in motifIcons set 170`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       link_off
     </span>
@@ -2745,6 +3087,8 @@ exports[`IconButton should render all icons in motifIcons set 171`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       list_alt
     </span>
@@ -2761,6 +3105,8 @@ exports[`IconButton should render all icons in motifIcons set 172`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       lists
     </span>
@@ -2777,6 +3123,8 @@ exports[`IconButton should render all icons in motifIcons set 173`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       local_library
     </span>
@@ -2793,6 +3141,8 @@ exports[`IconButton should render all icons in motifIcons set 174`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       local_mall
     </span>
@@ -2809,6 +3159,8 @@ exports[`IconButton should render all icons in motifIcons set 175`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       location_off
     </span>
@@ -2825,6 +3177,8 @@ exports[`IconButton should render all icons in motifIcons set 176`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       location_on
     </span>
@@ -2841,6 +3195,8 @@ exports[`IconButton should render all icons in motifIcons set 177`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       location_on_outline
     </span>
@@ -2857,6 +3213,8 @@ exports[`IconButton should render all icons in motifIcons set 178`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       lock
     </span>
@@ -2873,6 +3231,8 @@ exports[`IconButton should render all icons in motifIcons set 179`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       lock_open
     </span>
@@ -2889,6 +3249,8 @@ exports[`IconButton should render all icons in motifIcons set 180`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       logout
     </span>
@@ -2905,6 +3267,8 @@ exports[`IconButton should render all icons in motifIcons set 181`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       mail
     </span>
@@ -2921,6 +3285,8 @@ exports[`IconButton should render all icons in motifIcons set 182`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       mail_outline
     </span>
@@ -2937,6 +3303,8 @@ exports[`IconButton should render all icons in motifIcons set 183`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       map
     </span>
@@ -2953,6 +3321,8 @@ exports[`IconButton should render all icons in motifIcons set 184`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       mode_cool
     </span>
@@ -2969,6 +3339,8 @@ exports[`IconButton should render all icons in motifIcons set 185`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       mode_heat
     </span>
@@ -2985,6 +3357,8 @@ exports[`IconButton should render all icons in motifIcons set 186`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       more_horiz
     </span>
@@ -3001,6 +3375,8 @@ exports[`IconButton should render all icons in motifIcons set 187`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       more_time
     </span>
@@ -3017,6 +3393,8 @@ exports[`IconButton should render all icons in motifIcons set 188`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       more_vert
     </span>
@@ -3033,6 +3411,8 @@ exports[`IconButton should render all icons in motifIcons set 189`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       moving
     </span>
@@ -3049,6 +3429,8 @@ exports[`IconButton should render all icons in motifIcons set 190`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       nature
     </span>
@@ -3065,6 +3447,8 @@ exports[`IconButton should render all icons in motifIcons set 191`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       near_me
     </span>
@@ -3081,6 +3465,8 @@ exports[`IconButton should render all icons in motifIcons set 192`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       nest_eco_leaf
     </span>
@@ -3097,6 +3483,8 @@ exports[`IconButton should render all icons in motifIcons set 193`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       note
     </span>
@@ -3113,6 +3501,8 @@ exports[`IconButton should render all icons in motifIcons set 194`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       note_add
     </span>
@@ -3129,6 +3519,8 @@ exports[`IconButton should render all icons in motifIcons set 195`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       notifications
     </span>
@@ -3145,6 +3537,8 @@ exports[`IconButton should render all icons in motifIcons set 196`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       notifications_active
     </span>
@@ -3161,6 +3555,8 @@ exports[`IconButton should render all icons in motifIcons set 197`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       notifications_off
     </span>
@@ -3177,6 +3573,8 @@ exports[`IconButton should render all icons in motifIcons set 198`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       palette
     </span>
@@ -3193,6 +3591,8 @@ exports[`IconButton should render all icons in motifIcons set 199`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       passkey
     </span>
@@ -3209,6 +3609,8 @@ exports[`IconButton should render all icons in motifIcons set 200`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       payments
     </span>
@@ -3225,6 +3627,8 @@ exports[`IconButton should render all icons in motifIcons set 201`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       person
     </span>
@@ -3241,6 +3645,8 @@ exports[`IconButton should render all icons in motifIcons set 202`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       person_outline
     </span>
@@ -3257,6 +3663,8 @@ exports[`IconButton should render all icons in motifIcons set 203`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       phone_iphone
     </span>
@@ -3273,6 +3681,8 @@ exports[`IconButton should render all icons in motifIcons set 204`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       photo
     </span>
@@ -3289,6 +3699,8 @@ exports[`IconButton should render all icons in motifIcons set 205`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       photo_camera
     </span>
@@ -3305,6 +3717,8 @@ exports[`IconButton should render all icons in motifIcons set 206`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       photo_camera_outline
     </span>
@@ -3321,6 +3735,8 @@ exports[`IconButton should render all icons in motifIcons set 207`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       picture_as_pdf
     </span>
@@ -3337,6 +3753,8 @@ exports[`IconButton should render all icons in motifIcons set 208`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       pie_chart
     </span>
@@ -3353,6 +3771,8 @@ exports[`IconButton should render all icons in motifIcons set 209`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       plagiarism
     </span>
@@ -3369,6 +3789,8 @@ exports[`IconButton should render all icons in motifIcons set 210`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       podcasts
     </span>
@@ -3385,6 +3807,8 @@ exports[`IconButton should render all icons in motifIcons set 211`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       priority_high
     </span>
@@ -3401,6 +3825,8 @@ exports[`IconButton should render all icons in motifIcons set 212`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       privacy_tip
     </span>
@@ -3417,6 +3843,8 @@ exports[`IconButton should render all icons in motifIcons set 213`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       prompt_suggestion
     </span>
@@ -3433,6 +3861,8 @@ exports[`IconButton should render all icons in motifIcons set 214`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       psychiatry
     </span>
@@ -3449,6 +3879,8 @@ exports[`IconButton should render all icons in motifIcons set 215`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       push_pin
     </span>
@@ -3465,6 +3897,8 @@ exports[`IconButton should render all icons in motifIcons set 216`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       push_pin_outline
     </span>
@@ -3481,6 +3915,8 @@ exports[`IconButton should render all icons in motifIcons set 217`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       question_mark
     </span>
@@ -3497,6 +3933,8 @@ exports[`IconButton should render all icons in motifIcons set 218`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       receipt
     </span>
@@ -3513,6 +3951,8 @@ exports[`IconButton should render all icons in motifIcons set 219`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       receipt_long
     </span>
@@ -3529,6 +3969,8 @@ exports[`IconButton should render all icons in motifIcons set 220`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       remove
     </span>
@@ -3545,6 +3987,8 @@ exports[`IconButton should render all icons in motifIcons set 221`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       reply
     </span>
@@ -3561,6 +4005,8 @@ exports[`IconButton should render all icons in motifIcons set 222`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       schedule
     </span>
@@ -3577,6 +4023,8 @@ exports[`IconButton should render all icons in motifIcons set 223`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       schedule_outline
     </span>
@@ -3593,6 +4041,8 @@ exports[`IconButton should render all icons in motifIcons set 224`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       school
     </span>
@@ -3609,6 +4059,8 @@ exports[`IconButton should render all icons in motifIcons set 225`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       search
     </span>
@@ -3625,6 +4077,8 @@ exports[`IconButton should render all icons in motifIcons set 226`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       send
     </span>
@@ -3641,6 +4095,8 @@ exports[`IconButton should render all icons in motifIcons set 227`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       send_outline
     </span>
@@ -3657,6 +4113,8 @@ exports[`IconButton should render all icons in motifIcons set 228`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       sentiment_dissatisfied
     </span>
@@ -3673,6 +4131,8 @@ exports[`IconButton should render all icons in motifIcons set 229`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       sentiment_satisfied
     </span>
@@ -3689,6 +4149,8 @@ exports[`IconButton should render all icons in motifIcons set 230`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       settings
     </span>
@@ -3705,6 +4167,8 @@ exports[`IconButton should render all icons in motifIcons set 231`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       settings_outline
     </span>
@@ -3721,6 +4185,8 @@ exports[`IconButton should render all icons in motifIcons set 232`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       share
     </span>
@@ -3737,6 +4203,8 @@ exports[`IconButton should render all icons in motifIcons set 233`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       shield
     </span>
@@ -3753,6 +4221,8 @@ exports[`IconButton should render all icons in motifIcons set 234`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       shield_lock
     </span>
@@ -3769,6 +4239,8 @@ exports[`IconButton should render all icons in motifIcons set 235`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       signpost
     </span>
@@ -3785,6 +4257,8 @@ exports[`IconButton should render all icons in motifIcons set 236`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       sim_card
     </span>
@@ -3801,6 +4275,8 @@ exports[`IconButton should render all icons in motifIcons set 237`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       sim_card_outline
     </span>
@@ -3817,6 +4293,8 @@ exports[`IconButton should render all icons in motifIcons set 238`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       speed
     </span>
@@ -3833,6 +4311,8 @@ exports[`IconButton should render all icons in motifIcons set 239`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       stethoscope
     </span>
@@ -3849,6 +4329,8 @@ exports[`IconButton should render all icons in motifIcons set 240`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       store
     </span>
@@ -3865,6 +4347,8 @@ exports[`IconButton should render all icons in motifIcons set 241`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       supervisor_account
     </span>
@@ -3881,6 +4365,8 @@ exports[`IconButton should render all icons in motifIcons set 242`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       table_rows
     </span>
@@ -3897,6 +4383,8 @@ exports[`IconButton should render all icons in motifIcons set 243`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       task
     </span>
@@ -3913,6 +4401,8 @@ exports[`IconButton should render all icons in motifIcons set 244`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       task_alt
     </span>
@@ -3929,6 +4419,8 @@ exports[`IconButton should render all icons in motifIcons set 245`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       thumb_down
     </span>
@@ -3945,6 +4437,8 @@ exports[`IconButton should render all icons in motifIcons set 246`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       thumb_up
     </span>
@@ -3961,6 +4455,8 @@ exports[`IconButton should render all icons in motifIcons set 247`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       topic
     </span>
@@ -3977,6 +4473,8 @@ exports[`IconButton should render all icons in motifIcons set 248`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       touch_app
     </span>
@@ -3993,6 +4491,8 @@ exports[`IconButton should render all icons in motifIcons set 249`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       trophy
     </span>
@@ -4009,6 +4509,8 @@ exports[`IconButton should render all icons in motifIcons set 250`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       undo
     </span>
@@ -4025,6 +4527,8 @@ exports[`IconButton should render all icons in motifIcons set 251`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       upload
     </span>
@@ -4041,6 +4545,8 @@ exports[`IconButton should render all icons in motifIcons set 252`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       upload_2
     </span>
@@ -4057,6 +4563,8 @@ exports[`IconButton should render all icons in motifIcons set 253`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       upload_file
     </span>
@@ -4073,6 +4581,8 @@ exports[`IconButton should render all icons in motifIcons set 254`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       verified_user
     </span>
@@ -4089,6 +4599,8 @@ exports[`IconButton should render all icons in motifIcons set 255`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       videocam
     </span>
@@ -4105,6 +4617,8 @@ exports[`IconButton should render all icons in motifIcons set 256`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       videocam_off
     </span>
@@ -4121,6 +4635,8 @@ exports[`IconButton should render all icons in motifIcons set 257`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       visibility
     </span>
@@ -4137,6 +4653,8 @@ exports[`IconButton should render all icons in motifIcons set 258`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       visibility_off
     </span>
@@ -4153,6 +4671,8 @@ exports[`IconButton should render all icons in motifIcons set 259`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       volume_off
     </span>
@@ -4169,6 +4689,8 @@ exports[`IconButton should render all icons in motifIcons set 260`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       volume_up
     </span>
@@ -4185,6 +4707,8 @@ exports[`IconButton should render all icons in motifIcons set 261`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       volunteer_activism
     </span>
@@ -4201,6 +4725,8 @@ exports[`IconButton should render all icons in motifIcons set 262`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       vpn_key
     </span>
@@ -4217,6 +4743,8 @@ exports[`IconButton should render all icons in motifIcons set 263`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       vpn_key_off
     </span>
@@ -4233,6 +4761,8 @@ exports[`IconButton should render all icons in motifIcons set 264`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       warning
     </span>
@@ -4249,6 +4779,8 @@ exports[`IconButton should render all icons in motifIcons set 265`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       warning_outline
     </span>
@@ -4265,6 +4797,8 @@ exports[`IconButton should render all icons in motifIcons set 266`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       water_drop
     </span>
@@ -4281,6 +4815,8 @@ exports[`IconButton should render all icons in motifIcons set 267`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       waves
     </span>
@@ -4297,6 +4833,8 @@ exports[`IconButton should render all icons in motifIcons set 268`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       wb_sunny
     </span>
@@ -4313,6 +4851,8 @@ exports[`IconButton should render all icons in motifIcons set 269`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       work
     </span>
@@ -4329,6 +4869,8 @@ exports[`IconButton should render all icons in motifIcons set 270`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       work_outline
     </span>
@@ -4345,6 +4887,8 @@ exports[`IconButton should render all icons in motifIcons set 271`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       zoom_in
     </span>
@@ -4361,6 +4905,8 @@ exports[`IconButton should render all icons in motifIcons set 272`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       zoom_out
     </span>

--- a/src/lib/components/InputDate/__snapshots__/InputDate.test.tsx.snap
+++ b/src/lib/components/InputDate/__snapshots__/InputDate.test.tsx.snap
@@ -12,6 +12,8 @@ exports[`InputDate should be rendered with only required props and should have d
     >
       <span
         class="Root md motifIconsDefault icon"
+        lang="en"
+        translate="no"
       >
         calendar_month
       </span>

--- a/src/lib/components/InputDateRange/__snapshots__/InputDateRange.test.tsx.snap
+++ b/src/lib/components/InputDateRange/__snapshots__/InputDateRange.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`InputDateRange should be rendered with only required props and should h
     >
       <span
         class="Root md motifIconsDefault icon"
+        lang="en"
+        translate="no"
       >
         calendar_expand_horizontal
       </span>

--- a/src/lib/components/InputDateTime/__snapshots__/InputDateTime.test.tsx.snap
+++ b/src/lib/components/InputDateTime/__snapshots__/InputDateTime.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`InputDateTime should be rendered with only required props and should ha
     >
       <span
         class="Root md motifIconsDefault icon"
+        lang="en"
+        translate="no"
       >
         event
       </span>

--- a/src/lib/components/InputPassword/__snapshots__/InputPassword.test.tsx.snap
+++ b/src/lib/components/InputPassword/__snapshots__/InputPassword.test.tsx.snap
@@ -8,6 +8,8 @@ exports[`InputPassword should be rendered with only required props 1`] = `
   >
     <span
       class="Root md motifIconsDefault icon"
+      lang="en"
+      translate="no"
     >
       vpn_key
     </span>

--- a/src/lib/components/InputTime/__snapshots__/InputTime.test.tsx.snap
+++ b/src/lib/components/InputTime/__snapshots__/InputTime.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`InputTime should be rendered with only required props and should have d
     >
       <span
         class="Root md motifIconsDefault icon"
+        lang="en"
+        translate="no"
       >
         schedule
       </span>

--- a/src/lib/components/MenuList/__snapshots__/MenuList.test.tsx.snap
+++ b/src/lib/components/MenuList/__snapshots__/MenuList.test.tsx.snap
@@ -16,6 +16,8 @@ exports[`MenuList should be rendered with only required props and should have de
         >
           <span
             class="Root md mtf-ui-icons"
+            lang="en"
+            translate="no"
           >
             home
           </span>

--- a/src/lib/components/Motif/Icon/__snapshots__/MotifIcon.test.tsx.snap
+++ b/src/lib/components/Motif/Icon/__snapshots__/MotifIcon.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`MotifIcon should render with only required props 1`] = `
 <div>
   <span
     class="Root md motifIconsDefault"
+    lang="en"
+    translate="no"
   >
     home
   </span>

--- a/src/lib/components/Motif/Icon/__snapshots__/MotifIconButton.test.tsx.snap
+++ b/src/lib/components/Motif/Icon/__snapshots__/MotifIconButton.test.tsx.snap
@@ -9,6 +9,8 @@ exports[`MotifIconButton should render with only required props 1`] = `
   >
     <span
       class="Root md mtf-ui-icons"
+      lang="en"
+      translate="no"
     >
       home
     </span>

--- a/src/lib/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/lib/components/Select/__snapshots__/Select.test.tsx.snap
@@ -28,6 +28,8 @@ exports[`Select should be rendered with only required props 1`] = `
       >
         <span
           class="Root md motifIconsDefault iconRight arrowDown"
+          lang="en"
+          translate="no"
         >
           arrow_drop_down
         </span>

--- a/src/lib/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/lib/components/Table/__snapshots__/Table.test.tsx.snap
@@ -25,6 +25,8 @@ exports[`Table should render with only required props 1`] = `
               >
                 <span
                   class="Root md mtf-ui-icons sm"
+                  lang="en"
+                  translate="no"
                 >
                   expand_all
                 </span>

--- a/src/lib/components/Upload/ImageUpload/__snapshots__/ImageUpload.test.tsx.snap
+++ b/src/lib/components/Upload/ImageUpload/__snapshots__/ImageUpload.test.tsx.snap
@@ -10,6 +10,8 @@ exports[`ImageUpload should be rendered with only required props 1`] = `
     >
       <span
         class="Root md secondary motifIconsDefault addIcon"
+        lang="en"
+        translate="no"
       >
         add
       </span>

--- a/src/lib/components/Upload/UploadDragger/__snapshots__/UploadDragger.test.tsx.snap
+++ b/src/lib/components/Upload/UploadDragger/__snapshots__/UploadDragger.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`UploadDragger should be rendered with only required props 1`] = `
     >
       <span
         class="Root md secondary motifIconsDefault dragIcon"
+        lang="en"
+        translate="no"
       >
         upload_file
       </span>

--- a/src/lib/components/Upload/UploadInput/__snapshots__/UploadInput.test.tsx.snap
+++ b/src/lib/components/Upload/UploadInput/__snapshots__/UploadInput.test.tsx.snap
@@ -12,6 +12,8 @@ exports[`UploadInput should be rendered with only required props and should have
     >
       <span
         class="Root md motifIconsDefault"
+        lang="en"
+        translate="no"
       >
         search
       </span>


### PR DESCRIPTION
## Description

- Fixes icon breaking on browser translation.
- Added `translate="no"` and `lang="en"` attributes to Icon and IconButton components to prevent browser translation from modifying icon names.

<!-- Please describe your changes and how this PR provides a solution -->

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

### Before
<img width="800" alt="image" src="https://github.com/user-attachments/assets/3514323f-8050-488c-b0b0-cbde511e2ceb" />

### After
<img width="800" alt="image" src="https://github.com/user-attachments/assets/bce3d923-5cb4-42bf-aaa6-a109ff46c1d9" />


## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [x] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->

[#EDKUI-1395]