### PR TITLE
fix: library font family is added to storybook environment with higher hierarchy

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -4,6 +4,9 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/motif-ui/assets/css/motif-icons.css" />
 <style>
+  :where(div:not(.sb-anchor, .sb-unstyled, .sb-unstyled div)) {
+    font-family: "Inter", sans-serif !important;
+  }
   .sbdocs.sbdocs-preview,
   .docs-story,
   .docs-story > div {


### PR DESCRIPTION
## Description

Storybook font family is inherited from its own dist file, so font-family which is used for our library is reflected inside storybook components and only components itself.

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<img width="2560" height="1440" alt="font-family-2" src="https://github.com/user-attachments/assets/bb2f25c6-9f42-4b54-b807-365f1b3b2941" />

<img width="2560" height="1440" alt="fontfamily" src="https://github.com/user-attachments/assets/bae3d366-739e-4beb-abb6-92b153995bee" />

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

Local storybook could be checked.

<!-- Closes [#EDKUI-1386]: Internal purposes only -->
