### PR TITLE
revert: storybook build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "next build",
     "build:lib": "rollup -c",
-    "build:storybook": "storybook build --webpack-stats-json",
+    "build:storybook": "storybook build",
     "build:theme": "node src/scripts/buildTheme",
     "build:theme-default": "npm run build:theme src/lib/styles/tokens/design-tokens.tokens.json default-theme src/lib/styles/themes",
     "build:tokens": "node src/scripts/buildToken",


### PR DESCRIPTION
## Description

Putting --webpack-stats-json causes the storybook build to exceed the required size to upload it to Cloudflare. This revert fixes that.

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

-

<!-- Closes [#EDKUI-000]: Internal purposes only -->
