### PR TITLE
fix(Form): submit area margin top value is decreased

### DIFF
--- a/src/lib/components/Form/Form.module.scss
+++ b/src/lib/components/Form/Form.module.scss
@@ -37,8 +37,6 @@ $sizes: (
   }
 
   .submitArea {
-    margin-top: var(--base-sizing-10x);
-
     &.submitArea_align_left {
       justify-content: flex-start;
     }

--- a/src/lib/components/Form/Form.module.scss
+++ b/src/lib/components/Form/Form.module.scss
@@ -37,7 +37,7 @@ $sizes: (
   }
 
   .submitArea {
-    margin-top: var(--base-sizing-24x);
+    margin-top: var(--base-sizing-10x);
 
     &.submitArea_align_left {
       justify-content: flex-start;


### PR DESCRIPTION
## Description

Submit area margin top value is decreased from 24px to 10px. This px refinement suggested by design team. 

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

<img width="1259" height="317" alt="Screenshot 2026-07-21 at 15 29 04" src="https://github.com/user-attachments/assets/19408f2c-ff5d-41bb-8391-b26b423548e1" />


## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

```code
<Form onSubmit={data => alert(JSON.stringify(data))} size="md" alternateButtons={[<Button label="Atakan"/>]}>
        <Form.Field name="name" label="Name">
          <InputText value="Predefined name" />
        </Form.Field>

        <Form.Field name="age" label="Age" helperText="How old are you?">
          <Select
            data={[
              { label: "10", value: "10" },
              { label: "20", value: "20" },
              { label: "30", value: "30" },
            ]}
          />
        </Form.Field>
      </Form>
```

<!-- Closes [#EDKUI-1465]: Internal purposes only -->
