### PR TITLE
fix(Toast): toast loader time sync problem is fixed

### DIFF
--- a/src/lib/components/ProgressBar/ProgressBar.tsx
+++ b/src/lib/components/ProgressBar/ProgressBar.tsx
@@ -34,7 +34,8 @@ const ProgressBar = (props: PropsWithRef<ProgressBarProps, HTMLDivElement>) => {
   const classNames = sanitizeModuleRootClasses(styles, className, [
     variant,
     size,
-    indeterminate ? "indeterminate" : countdown && "countdown" + (countdown.paused ? " " + "paused" : ""),
+    indeterminate ? "indeterminate" : countdown && "countdown",
+    !indeterminate && countdown?.paused && "paused",
   ]);
 
   return (


### PR DESCRIPTION
## Description

Paused value has been passed through to ProgresBar component to activate hover effect of Toast component.

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

https://github.com/user-attachments/assets/f239f7be-3e90-4110-beaf-1269cb841be3

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

```code
"use client";

import { useMotifContext } from "../lib/motif/context/MotifProvider";
import { useToast } from "@/components/Toast";
import Button from "@/components/Button";
import ProgressBar from "@/components/ProgressBar";
import ProgressCircle from "@/components/ProgressCircle";

const Home = () => {
  const { t } = useMotifContext();

  const toast = useToast();

  return (
    <div style={{ margin: "0 auto", padding: 20 }}>
      <h2>{t("g.hello_x", { name: "MOTİF UI" })}</h2>
      <h4>{t("misc.playgroundDescription")}</h4>
      <Button variant="warning" onClick={() => toast.warning("Toast content")} label="Warning" />
      {toast.toasts}

      <div
        style={{
          textAlign: "center",
          width: 300,
        }}
      >
        <ProgressBar progress={65} countdown={{ duration: 10000, paused: false }} />
      </div>

      <div
        style={{
          textAlign: "center",
          width: 1000,
        }}
      >
        <ProgressCircle size="xl" progress={65} countdown={{ duration: 10000, paused: false }} />
      </div>
    </div>
  );
};

export default Home;

```

<!-- Closes [#EDKUI-1457]: Internal purposes only -->
