### PR TITLE
fix(DateRangePicker, InputDateRange): firstDayOfWeek support

### DIFF
--- a/src/lib/components/DatePicker/components/DateSelector/Day/DaySelector.tsx
+++ b/src/lib/components/DatePicker/components/DateSelector/Day/DaySelector.tsx
@@ -5,12 +5,14 @@ import styles from "../../../DatePicker.module.scss";
 import { DayProps } from "@/components/DatePicker/components/DateSelector/Day/Day";
 import { Size4SM } from "../../../../../types";
 import { DatePickerLocale } from "@/components/DatePicker/types";
+import { DaysOfWeek } from "@/components/Motif/Pickers/types";
 import Header from "@/components/DatePicker/components/Header/Header";
 import WeekDays from "@/components/DatePicker/components/DateSelector/Day/WeekDays";
 
 type Props = {
   size: Size4SM;
   locale: DatePickerLocale;
+  firstDayOfWeek: DaysOfWeek;
   month: number;
   year: number;
   onPrevClick?: () => void;
@@ -22,7 +24,7 @@ type Props = {
 };
 
 const DaySelector = (props: Props) => {
-  const { size, locale, month, year, onPrevClick, onNextClick, disabledMonthYearClick, daysRef, dates, renderDay } = props;
+  const { size, locale, firstDayOfWeek, month, year, onPrevClick, onNextClick, disabledMonthYearClick, daysRef, dates, renderDay } = props;
 
   return (
     <div className={`${styles.daySelector} ${styles[size]}`}>
@@ -34,7 +36,7 @@ const DaySelector = (props: Props) => {
         disableButtons={disabledMonthYearClick}
         size={size}
       />
-      <WeekDays locale={locale} />
+      <WeekDays locale={locale} firstDayOfWeek={firstDayOfWeek} />
       <div className={styles.days} ref={daysRef} data-testid="DatePickerDayContainer">
         {dates.map(renderDay)}
       </div>

--- a/src/lib/components/DatePicker/components/DateSelector/Day/DaySelectorWithMonthYear.tsx
+++ b/src/lib/components/DatePicker/components/DateSelector/Day/DaySelectorWithMonthYear.tsx
@@ -52,6 +52,7 @@ const DaySelectorWithMonthYear = () => {
     <DaySelector
       size={size}
       locale={locale}
+      firstDayOfWeek={firstDayOfWeek}
       month={pickerDate.getMonth()}
       year={pickerDate.getFullYear()}
       dates={displayedWeeks.flat()}

--- a/src/lib/components/DatePicker/components/DateSelector/Day/WeekDays.tsx
+++ b/src/lib/components/DatePicker/components/DateSelector/Day/WeekDays.tsx
@@ -1,15 +1,14 @@
 import styles from "../../../DatePicker.module.scss";
 import { rotateArray } from "../../../../../../utils/utils";
 import { DatePickerLocale } from "@/components/DatePicker/types";
-import { useContext } from "react";
-import { DatePickerContext } from "@/components/DatePicker/context/DatePickerProvider.tsx";
+import { DaysOfWeek } from "@/components/Motif/Pickers/types";
 
 type Props = {
   locale: DatePickerLocale;
+  firstDayOfWeek: DaysOfWeek;
 };
 
-const WeekDays = ({ locale }: Props) => {
-  const { firstDayOfWeek } = useContext(DatePickerContext);
+const WeekDays = ({ locale, firstDayOfWeek }: Props) => {
   return (
     <div className={styles.weekDays}>
       {rotateArray(locale.weekDays, "left", firstDayOfWeek).map(day => (

--- a/src/lib/components/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/lib/components/DateRangePicker/DateRangePicker.stories.tsx
@@ -10,6 +10,7 @@ const meta: Meta<typeof DateRangePicker> = {
   argTypes: {
     variant: { table: { defaultValue: { summary: "borderless" } } },
     size: { table: { defaultValue: { summary: "md" } } },
+    firstDayOfWeek: { table: { defaultValue: { summary: "1" } } },
   },
   args: {
     variant: "shadow",

--- a/src/lib/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/src/lib/components/DateRangePicker/DateRangePicker.test.tsx
@@ -364,4 +364,11 @@ describe("DateRangePicker", () => {
     expect(startDateButton).toHaveClass("selected");
     expect(endDateButton).toHaveClass("selected");
   });
+
+  it("should reflect the day arrangement given in the firstDayOfWeek prop", () => {
+    const mockStartDate = new Date(year - 20, month, 1);
+    const mockEndDate = new Date(year - 20, month + 1, 25);
+    const { container } = render(<DateRangePicker firstDayOfWeek={3} value={[mockStartDate, mockEndDate]} />);
+    expect(container.firstElementChild?.getElementsByClassName("weekDays")[0].firstElementChild?.textContent).toBe("We");
+  });
 });

--- a/src/lib/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/lib/components/DateRangePicker/DateRangePicker.tsx
@@ -17,6 +17,7 @@ const DateRangePicker = (props: PropsWithRef<DateRangePickerProps, HTMLDivElemen
     onOkClick,
     onClearClick,
     removeActionButtons,
+    firstDayOfWeek = 1,
     className,
     style,
   } = usePropsWithThemeDefaults("DateRangePicker", props);
@@ -24,7 +25,7 @@ const DateRangePicker = (props: PropsWithRef<DateRangePickerProps, HTMLDivElemen
   const locale = useDateLocale(propsLocale);
   return (
     <Picker size={size} variant={variant} wide ref={ref} style={style} className={`mtf-DateRangePicker ${className ?? ""}`.trim()}>
-      <DateRangePickerProvider value={value} size={size} locale={locale} onDateChange={onDateChange}>
+      <DateRangePickerProvider value={value} size={size} locale={locale} firstDayOfWeek={firstDayOfWeek} onDateChange={onDateChange}>
         <DateRangePickerContainer removeActionButtons={removeActionButtons} onOkClick={onOkClick} onClearClick={onClearClick} />
       </DateRangePickerProvider>
     </Picker>

--- a/src/lib/components/DateRangePicker/components/CustomDatePicker.tsx
+++ b/src/lib/components/DateRangePicker/components/CustomDatePicker.tsx
@@ -15,6 +15,7 @@ const CustomDatePicker = (props: Props) => {
   const {
     size,
     locale,
+    firstDayOfWeek,
     dateCouple: [startDate, endDate],
     today,
     months,
@@ -94,6 +95,7 @@ const CustomDatePicker = (props: Props) => {
     <DaySelector
       size={size}
       locale={locale}
+      firstDayOfWeek={firstDayOfWeek}
       month={pickerDate.getMonth()}
       year={pickerDate.getFullYear()}
       disabledMonthYearClick

--- a/src/lib/components/DateRangePicker/context/DateRangePickerProvider.tsx
+++ b/src/lib/components/DateRangePicker/context/DateRangePickerProvider.tsx
@@ -13,12 +13,9 @@ import { calculateWeeksFlat } from "@/components/DatePicker/components/helper";
 export const DateRangePickerContext = createContext<DateRangePickerContextProps>(datePickerContextDefaultValues);
 
 export const DateRangePickerProvider = (props: PropsWithChildren<DateRangePickerProviderProps>) => {
-  const { value, locale, size, onDateChange, children } = props;
+  const { value, locale, size, firstDayOfWeek, onDateChange, children } = props;
 
-  //TODO: With the changes of firstDayOfWeek seperation inside DatePicker, reaching out from local.firstDayOfWeek is
-  // not possible, so default value is given inside this method to convert back to normal when task is completed.
-  // Issue number is: 1441
-  const getDaysOfMonth = useCallback((month: Date) => calculateWeeksFlat(month, 1), []);
+  const getDaysOfMonth = useCallback((month: Date) => calculateWeeksFlat(month, firstDayOfWeek), [firstDayOfWeek]);
   const today = useMemo(() => DateUtils.getTodayTimeless(), []);
   const initialMonths = useMemo(
     () => [
@@ -52,6 +49,7 @@ export const DateRangePickerProvider = (props: PropsWithChildren<DateRangePicker
     () => ({
       locale,
       size,
+      firstDayOfWeek,
       dateCouple,
       setDateCouple,
       sliding,
@@ -64,7 +62,7 @@ export const DateRangePickerProvider = (props: PropsWithChildren<DateRangePicker
       initialMonths,
       partialSelection,
     }),
-    [locale, size, dateCouple, sliding, months, today, onDateChange, getDaysOfMonth, initialMonths, partialSelection],
+    [locale, size, firstDayOfWeek, dateCouple, sliding, months, today, onDateChange, getDaysOfMonth, initialMonths, partialSelection],
   );
 
   return <DateRangePickerContext value={contextValue}>{children}</DateRangePickerContext>;

--- a/src/lib/components/DateRangePicker/types.ts
+++ b/src/lib/components/DateRangePicker/types.ts
@@ -1,4 +1,4 @@
-import { PickerPropsCommon } from "../Motif/Pickers/types";
+import { DaysOfWeek, PickerPropsCommon } from "../Motif/Pickers/types";
 import { Size4SM } from "../../types";
 import { Dispatch, SetStateAction } from "react";
 import { DatePickerLocale } from "../DatePicker/types";
@@ -39,18 +39,21 @@ export type DateRangePickerDefaultableProps = {
    */
   locale?: DateRangePickerLocale;
   removeActionButtons?: boolean;
+  firstDayOfWeek?: DaysOfWeek;
 } & Omit<PickerPropsCommon, "fluid">;
 
 export type DateRangePickerProviderProps = {
   value: (Date | undefined)[] | undefined;
   locale: DateRangePickerLocale;
   size: Size4SM;
+  firstDayOfWeek: DaysOfWeek;
   onDateChange?: (dates: (Date | undefined)[]) => void;
 };
 
 export type DateRangePickerContextProps = {
   locale: DateRangePickerLocale;
   size: Size4SM;
+  firstDayOfWeek: DaysOfWeek;
   dateCouple: (Date | undefined)[];
   setDateCouple: Dispatch<SetStateAction<(Date | undefined)[]>>;
   sliding: "slideLeft" | "slideRight" | undefined;
@@ -73,6 +76,7 @@ export type DateRangePickerLocale = {
 
 export const datePickerContextDefaultValues: DateRangePickerContextProps = {
   size: "md",
+  firstDayOfWeek: 1,
   dateCouple: [undefined, undefined],
   setSliding: () => {},
   sliding: undefined,

--- a/src/lib/components/InputDateRange/InputDateRange.stories.tsx
+++ b/src/lib/components/InputDateRange/InputDateRange.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof InputDateRange> = {
     locale: { table: { defaultValue: { summary: "Turkish" } } },
     size: { table: { defaultValue: { summary: "md" } } },
     placeholder: { table: { defaultValue: { summary: "Reflects format prop" } } },
+    firstDayOfWeek: { table: { defaultValue: { summary: "1" } } },
   },
   args: {
     value: [new Date(today), new Date(today.getFullYear(), today.getMonth(), today.getDate() + 7)],

--- a/src/lib/components/InputDateRange/InputDateRange.test.tsx
+++ b/src/lib/components/InputDateRange/InputDateRange.test.tsx
@@ -261,4 +261,10 @@ describe("InputDateRange", () => {
     const { getDateRangeInput } = renderExt(<InputDateRange value={testDateArr.reverse()} />);
     expect(getDateRangeInput()).toHaveValue(testDateString);
   });
+
+  it("should reflect the day arrangement given in the firstDayOfWeek prop", async () => {
+    const { container, getDateRangeInput } = renderExt(<InputDateRange firstDayOfWeek={3} value={testDateArr} />);
+    await userEvent.click(getDateRangeInput());
+    expect(container.firstElementChild?.getElementsByClassName("weekDays")[0].firstElementChild?.textContent).toBe("We");
+  });
 });

--- a/src/lib/components/InputDateRange/InputDateRange.tsx
+++ b/src/lib/components/InputDateRange/InputDateRange.tsx
@@ -31,7 +31,7 @@ export const pickerSizeMap = {
 
 const InputDateRange = (p: PropsWithRef<InputDateRangeProps, HTMLDivElement>) => {
   const props = usePropsWithThemeDefaults("InputDateRange", p);
-  const { pill, value, onChange, locale: propsLocale, ref, style, className } = props;
+  const { pill, value, onChange, locale: propsLocale, ref, style, className, firstDayOfWeek } = props;
   const format = useMemo(() => ({ ...defaultDateFormat, ...props.format }), [props.format]);
   const datePlaceholder = format.order.map(part => format[`${part}Format`]?.replace(/[DMY]/g, "_")).join(` ${format.delimiter} `);
   const placeholder = useMemo(
@@ -142,6 +142,7 @@ const InputDateRange = (p: PropsWithRef<InputDateRangeProps, HTMLDivElement>) =>
       />
       {visible && (
         <DateRangePicker
+          firstDayOfWeek={firstDayOfWeek}
           variant="bordered"
           size={pickerSizeMap[size]}
           value={itemValue}

--- a/src/lib/components/InputDateRange/types.ts
+++ b/src/lib/components/InputDateRange/types.ts
@@ -1,4 +1,4 @@
-import { DateFormat } from "../Motif/Pickers/types";
+import { DateFormat, DaysOfWeek } from "../Motif/Pickers/types";
 import { InputCommonProps, InputSize } from "../Form/types";
 import type { DateRangePickerLocale } from "../DateRangePicker/types";
 
@@ -10,4 +10,5 @@ export type InputDateRangeDefaultableProps = {
   size?: InputSize;
   format?: DateFormat;
   locale?: DateRangePickerLocale;
+  firstDayOfWeek?: DaysOfWeek;
 };


### PR DESCRIPTION
## Description

Since both `DatePicker` and `DateRangePicker` share the same `DaySelector` component, the context was previously used only for `firstDayOfWeek`, while other properties such as `size` and `locale` were already passed via props. To keep the API consistent and remove this unnecessary context dependency, `firstDayOfWeek` is now passed through props as well.

Additionally, managing `firstDayOfWeek` through context caused `DatePickerContext` and `DateRangePickerContext` to influence the shared `DaySelector` independently, creating an implicit coupling between two otherwise unrelated contexts. Passing `firstDayOfWeek` as a prop eliminates this interaction and makes the data flow explicit and predictable.

As part of this change, `firstDayOfWeek` prop support has been added to both `DateRangePicker` and `InputDateRange`. Related stories and test files have been updated, and the behavior has been verified with different locale configurations.

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [x] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->
<img width="1987" height="575" alt="Screenshot 2026-07-23 at 16 41 49" src="https://github.com/user-attachments/assets/75ed665b-0ac8-4c03-8fe7-414582623426" />
<img width="1937" height="616" alt="Screenshot 2026-07-23 at 16 41 33" src="https://github.com/user-attachments/assets/0454503b-8bc5-4096-99b6-3ab84d790244" />

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [x] Tests added/updated and passing
- [x] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->

```code
      <DatePicker firstDayOfWeek={3} />
      <DateRangePicker firstDayOfWeek={3} />
      <InputDate firstDayOfWeek={2} />
      <InputDateRange firstDayOfWeek={2} />
```

<!-- Closes [#EDKUI-1441]: Internal purposes only -->
