### PR TITLE
fix: sass if function deprecation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,9 +4,6 @@ import { applyCustomCSSModuleNaming } from "@styles/scripts/build";
 
 const nextConfig: NextConfig = {
   reactStrictMode: false,
-  sassOptions: {
-    silenceDeprecations: ["if-function"],
-  },
   turbopack: {},
   compiler: {
     reactRemoveProperties:

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -93,7 +93,6 @@ export default [
         },
         sass: {
           includePaths: [path.resolve(__dirname, "src/lib/styles")],
-          silenceDeprecations: ["if-function"],
           importer: [
             function (url) {
               // resolves @styles/... imports

--- a/src/lib/components/Avatar/Avatar.module.scss
+++ b/src/lib/components/Avatar/Avatar.module.scss
@@ -50,6 +50,6 @@ $variants: ("primary", "secondary", "info", "success", "warning", "danger");
 }
 @each $variant in $variants {
   .#{$variant} {
-    background-color: if($variant == "secondary", var(--theme-color-surface-base-base7), var(--theme-color-surface-#{$variant}-default));
+    background-color: if(sass($variant == "secondary"): var(--theme-color-surface-base-base7); else: var(--theme-color-surface-#{$variant}-default));
   }
 }

--- a/src/lib/components/Badge/Badge.module.scss
+++ b/src/lib/components/Badge/Badge.module.scss
@@ -12,7 +12,7 @@ $positions: ("top-left", "top-right", "bottom-left", "bottom-right");
 
   #{$vertical}: 0;
   #{$horizontal}: 0;
-  transform: translateX(if($horizontal == "left", -50%, 50%)) translateY(if($vertical == "top", -75%, 75%));
+  transform: translateX(if(sass($horizontal == "left"): -50%; else: 50%)) translateY(if(sass($vertical == "top"): -75%; else: 75%));
 }
 
 .Root {
@@ -46,8 +46,8 @@ $positions: ("top-left", "top-right", "bottom-left", "bottom-right");
 
   @each $variant in $variants {
     .#{$variant} & {
-      background-color: if($variant == "secondary", var(--theme-color-surface-base-base7), var(--theme-color-surface-#{$variant}-default));
-      color: if($variant == "warning", var(--theme-color-text-base-global-dark), var(--theme-color-text-base-global-light));
+      background-color: if(sass($variant == "secondary"): var(--theme-color-surface-base-base7); else: var(--theme-color-surface-#{$variant}-default));
+      color: if(sass($variant == "warning"): var(--theme-color-text-base-global-dark); else: var(--theme-color-text-base-global-light));
     }
   }
 

--- a/src/lib/components/BusinessCard/BusinessCard.module.scss
+++ b/src/lib/components/BusinessCard/BusinessCard.module.scss
@@ -91,7 +91,7 @@ $variants: (("neutral", "light"), ("primary", "primary"), ("secondary", "seconda
         .link,
         .icon,
         .iconButton {
-          $tone: if($variant == "warning", "dark", "light");
+          $tone: if(sass($variant == "warning"): "dark"; else: "light");
           color: var(--theme-color-text-base-global-#{$tone});
         }
       } @else {

--- a/src/lib/components/Button/Button.module.scss
+++ b/src/lib/components/Button/Button.module.scss
@@ -20,9 +20,8 @@ $variants: (
 );
 @mixin text-color-on-surface($variant, $textColor, $state: null) {
   color: if(
-    $variant == "warning" and $state == "disabled",
-    var(--theme-color-text-base-dark-overlay50),
-    if($variant == "secondary" and $state != null, var(--theme-color-text-light-#{$state}), var($textColor))
+    sass($variant == "warning" and $state == "disabled"): var(--theme-color-text-base-dark-overlay50);
+      else: if(sass($variant == "secondary" and $state != null): var(--theme-color-text-light-#{$state}); else: var($textColor))
   );
 }
 @mixin state-background-color($color, $state, $shape) {

--- a/src/lib/components/Chip/Chip.module.scss
+++ b/src/lib/components/Chip/Chip.module.scss
@@ -55,7 +55,7 @@ $variants: (
           background-color: var(--theme-color-surface-#{$color}-hover);
           &,
           .icon-close {
-            color: if($variant == "secondary", var(--theme-color-text-light-hover), var(--theme-color-text-#{$colorSolid}));
+            color: if(sass($variant == "secondary"): var(--theme-color-text-light-hover); else: var(--theme-color-text-#{$colorSolid}));
           }
         }
       }
@@ -63,7 +63,7 @@ $variants: (
 
     &.outline {
       border: solid var(--base-sizing-1x) var(--theme-color-border-#{$color}-default);
-      color: if($variant == "warning", var(--theme-color-text-warning-hover), var(--theme-color-text-#{$color}-default));
+      color: if(sass($variant == "warning"): var(--theme-color-text-warning-hover); else: var(--theme-color-text-#{$color}-default));
 
       &.closable {
         @include transition(color border-color);
@@ -74,7 +74,7 @@ $variants: (
           border-color: var(--theme-color-border-#{$color}-hover);
           &,
           .icon-close {
-            color: if($variant == "warning", var(--theme-color-text-warning-active), var(--theme-color-text-#{$color}-hover));
+            color: if(sass($variant == "warning"): var(--theme-color-text-warning-active); else: var(--theme-color-text-#{$color}-hover));
           }
         }
       }

--- a/src/lib/components/Dropdown/Dropdown.module.scss
+++ b/src/lib/components/Dropdown/Dropdown.module.scss
@@ -105,10 +105,10 @@ $variants: ("primary", "secondary", "info", "success", "warning", "danger");
   }
 
   @each $variant in $variants {
-    $color: if($variant == "secondary", "light", $variant);
+    $color: if(sass($variant == "secondary"): "light"; else: $variant);
     .solid.#{$variant} & {
       background-color: var(--theme-color-surface-#{$color}-default);
-      color: if($variant == "secondary" or $variant == "warning", var(--theme-color-text-base-title), var(--theme-color-text-base-global-light));
+      color: if(sass($variant == "secondary" or $variant == "warning"): var(--theme-color-text-base-title); else: var(--theme-color-text-base-global-light));
 
       @each $state in $states {
         &:#{$state} {

--- a/src/lib/components/NavBar/NavBar.module.scss
+++ b/src/lib/components/NavBar/NavBar.module.scss
@@ -215,34 +215,33 @@ $variants: ("neutral", "primary", "secondary", "info", "danger", "warning", "suc
 // =============================================================================
 @each $variant in $variants {
   .#{$variant} {
-    background-color: if($variant == "neutral", var(--theme-color-surface-base-base4), var(--theme-color-surface-#{$variant}-default));
+    background-color: if(sass($variant == "neutral"): var(--theme-color-surface-base-base4); else: var(--theme-color-surface-#{$variant}-default));
 
     .hamburger,
     .menuBarItem > a {
-      color: if($variant == "neutral" or $variant == "warning", var(--theme-color-text-base-subtitle), var(--theme-color-text-base-light-overlay75));
+      color: if(sass($variant == "neutral" or $variant == "warning"): var(--theme-color-text-base-subtitle); else: var(--theme-color-text-base-light-overlay75));
     }
     .hamburger:hover,
     .menuBarItem > a:hover,
     .menuBarItem.active > a {
-      color: if($variant == "neutral" or $variant == "warning", var(--theme-color-text-base-text-dark), var(--theme-color-text-base-global-light));
+      color: if(sass($variant == "neutral" or $variant == "warning"): var(--theme-color-text-base-text-dark); else: var(--theme-color-text-base-global-light));
     }
 
     @include screen-width("below", "sm") {
       .mainMenu {
         :has(.subMenu) > a {
-          color: if($variant == "neutral" or $variant == "warning", var(--theme-color-text-base-text-dark), var(--theme-color-text-base-global-light));
+          color: if(sass($variant == "neutral" or $variant == "warning"): var(--theme-color-text-base-text-dark); else: var(--theme-color-text-base-global-light));
         }
         .menuBarItem > a {
-          border-color: if($variant == "neutral", var(--theme-color-border-light-default), var(--theme-color-surface-base-light-overlay50));
+          border-color: if(sass($variant == "neutral"): var(--theme-color-border-light-default); else: var(--theme-color-surface-base-light-overlay50));
         }
         .subMenuItem a {
-          color: if($variant == "neutral" or $variant == "warning", var(--theme-color-text-base-subtitle), var(--theme-color-text-base-light-overlay75));
+          color: if(sass($variant == "neutral" or $variant == "warning"): var(--theme-color-text-base-subtitle); else: var(--theme-color-text-base-light-overlay75));
           &:hover {
-            color: if($variant == "neutral" or $variant == "warning", var(--theme-color-text-base-text-dark), var(--theme-color-text-base-global-light));
+            color: if(sass($variant == "neutral" or $variant == "warning"): var(--theme-color-text-base-text-dark); else: var(--theme-color-text-base-global-light));
             background-color: if(
-              $variant == "neutral",
-              var(--theme-color-surface-light-hover),
-              if($variant == "warning", var(--theme-color-surface-base-light-overlay25), var(--theme-color-surface-base-dark-overlay15))
+              sass($variant == "neutral"): var(--theme-color-surface-light-hover);
+                else: if(sass($variant == "warning"): var(--theme-color-surface-base-light-overlay25); else: var(--theme-color-surface-base-dark-overlay15))
             );
           }
         }

--- a/src/lib/components/Popover/Popover.module.scss
+++ b/src/lib/components/Popover/Popover.module.scss
@@ -100,7 +100,7 @@ $caret-margin: var(--base-sizing-12x);
   .popover {
     &::before {
       border-width: map.get($values, "borderWidth");
-      border-#{map.get($values, "caretPosition")}-color: if($borderColor, $borderColor, $color);
+      border-#{map.get($values, "caretPosition")}-color: if(sass($borderColor): $borderColor; else: $color);
       inset: map.get($values, "beforePos");
       margin: map.get($values, "margin");
 

--- a/src/lib/components/Stepper/Stepper.module.scss
+++ b/src/lib/components/Stepper/Stepper.module.scss
@@ -202,7 +202,7 @@ $types: (("dot", var(--base-sizing-12x)), ("number", var(--base-sizing-24x)), ("
 
     &.completed {
       .title {
-        color: if($variant == "secondary", var(--theme-color-text-#{$variant}-hover), var(--theme-color-text-#{$variant}-default));
+        color: if(sass($variant == "secondary"): var(--theme-color-text-#{$variant}-hover); else: var(--theme-color-text-#{$variant}-default));
       }
       .stepIndicator {
         background-color: var(--theme-color-surface-#{$variant}-default);

--- a/src/lib/components/Timeline/Timeline.module.scss
+++ b/src/lib/components/Timeline/Timeline.module.scss
@@ -17,18 +17,18 @@ $variants: (
   background-color: var(--theme-color-border-light-default);
 
   @if $orientation == "vertical" {
-    min-height: if($half, var(--base-sizing-12x), var(--base-sizing-24x));
+    min-height: if(sass($half): var(--base-sizing-12x); else: var(--base-sizing-24x));
     width: var(--base-sizing-1x);
   } @else if $orientation == "horizontal" {
-    min-width: if($half, var(--base-sizing-12x), var(--base-sizing-24x));
+    min-width: if(sass($half): var(--base-sizing-12x); else: var(--base-sizing-24x));
     height: var(--base-sizing-1x);
   }
 }
 
 @mixin marker-variant($variant, $fill-text-token, $self: false) {
-  $base: if($self, "&", "");
-  $outlined-disabled: if($self, "&.disabled.outlined", ".item.disabled.outlined");
-  $filled-disabled: if($self, "&.disabled.filled", ".item.disabled.filled");
+  $base: if(sass($self): "&"; else: "");
+  $outlined-disabled: if(sass($self): "&.disabled.outlined"; else: ".item.disabled.outlined");
+  $filled-disabled: if(sass($self): "&.disabled.filled"; else: ".item.disabled.filled");
 
   #{$base}.outlined .marker span {
     border-color: var(--theme-color-border-#{$variant}-default);
@@ -41,12 +41,15 @@ $variants: (
   }
 
   #{$outlined-disabled} .marker span {
-    border-color: if($variant == "light", var(--theme-color-border-light-default), if($variant == "secondary", var(--theme-color-surface-base-base7), var(--theme-color-border-#{$variant}-disabled)));
-    color: if($variant == "light", var(--theme-color-text-secondary-disabled), var(--theme-color-text-#{$variant}-disabled));
+    border-color: if(
+      sass($variant == "light"): var(--theme-color-border-light-default);
+        else: if(sass($variant == "secondary"): var(--theme-color-surface-base-base7); else: var(--theme-color-border-#{$variant}-disabled))
+    );
+    color: if(sass($variant == "light"): var(--theme-color-text-secondary-disabled); else: var(--theme-color-text-#{$variant}-disabled));
   }
 
   #{$filled-disabled} .marker span {
-    background-color: if($variant == "secondary", var(--theme-color-surface-base-base7), var(--theme-color-surface-#{$variant}-disabled));
+    background-color: if(sass($variant == "secondary"): var(--theme-color-surface-base-base7); else: var(--theme-color-surface-#{$variant}-disabled));
     @if $variant == "warning" {
       color: var(--theme-color-text-base-dark-overlay25);
     } @else if $variant == "light" {


### PR DESCRIPTION
## Description

- Migrated Sass's deprecated positional if() syntax (if(cond, a, b)) to the new recommended form if(sass(cond): a; else: b) — deprecated as of Sass 1.95+
- Affected 10 components: Avatar, Badge, BusinessCard, Button, Chip, Dropdown, NavBar, Popover, Stepper, Timeline
- Removed the now-unnecessary silenceDeprecations: ["if-function"] from next.config.ts and rollup.config.mjs
-  All files compile with 0 errors / 0 deprecation warnings via the Sass compiler
-  npm run build:lib (rollup) completes successfully
-  npm run check:type passes clean
-  Storybook builds 100% in the real dev environment with no Sass warnings

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [x] 🧹 Code Refactoring

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [x] Tests added/updated and passing
- [ ] Storybook story added/updated


<!-- Brief steps for reviewers -->

<!-- Closes [#EDKUI-1270] -->
