### PR TITLE
fix(Table): locale-aware case normalization for filter matching

### DIFF
--- a/src/lib/components/Table/Table.test.tsx
+++ b/src/lib/components/Table/Table.test.tsx
@@ -5,10 +5,14 @@ import { ReactNode } from "react";
 import { userEvent } from "@testing-library/user-event";
 import { RowColor } from "@/components/Table/types";
 import { t } from "./../../../utils/testUtils";
+import MotifProvider from "../../motif/context/MotifProvider";
 
 describe("Table", () => {
-  const cols = [{ title: "Test Title", dataKey: "testData", sorting: {} }];
-  const data = [{ testData: "M Test" }, { testData: "A Test" }, { testData: "Z Test" }];
+  const cols = [
+    { title: "Test Title", dataKey: "testData", sorting: {} },
+    { title: "Şehir", dataKey: "city", filter: true },
+  ];
+  const data = [{ testData: "M Test", city: "İSTANBUL" }, { testData: "A Test", city: "BERLİN" }, { testData: "Z Test" }];
   const renderExt = (ui: ReactNode) => {
     const result = render(ui);
     const { getByTestId, getAllByTestId, queryByTestId, getByRole, container } = result;
@@ -1085,5 +1089,23 @@ describe("Table", () => {
     const filterInput = getFilterableTableInput();
     expect(filterInput).toHaveAttribute("placeholder", customPlaceholder);
     expect(getColumnFilterInputs()[0]).toHaveAttribute("placeholder", namePlaceholder);
+  });
+
+  it("should match uppercase İSTANBUL when searching istanbul with locale=tr", async () => {
+    const { getFilterableTableInput } = renderExt(<Table columns={cols} data={data} filterableTable />);
+    await userEvent.type(getFilterableTableInput(), "istanbul");
+    expect(screen.getByText("İSTANBUL")).toBeInTheDocument();
+    expect(screen.queryByText("BERLİN")).not.toBeInTheDocument();
+  });
+
+  it("should match uppercase BERLİN when searching berlin with locale=en", async () => {
+    const { getFilterableTableInput } = renderExt(
+      <MotifProvider locale="en">
+        <Table columns={cols} data={data} filterableTable />
+      </MotifProvider>,
+    );
+    await userEvent.type(getFilterableTableInput(), "berlin");
+    expect(screen.getByText("BERLİN")).toBeInTheDocument();
+    expect(screen.queryByText("İSTANBUL")).not.toBeInTheDocument();
   });
 });

--- a/src/lib/components/Table/Table.test.tsx
+++ b/src/lib/components/Table/Table.test.tsx
@@ -12,7 +12,7 @@ describe("Table", () => {
     { title: "Test Title", dataKey: "testData", sorting: {} },
     { title: "Şehir", dataKey: "city", filter: true },
   ];
-  const data = [{ testData: "M Test", city: "İSTANBUL" }, { testData: "A Test", city: "BERLİN" }, { testData: "Z Test" }];
+  const data = [{ testData: "M Test" }, { testData: "A Test" }, { testData: "Z Test" }];
   const renderExt = (ui: ReactNode) => {
     const result = render(ui);
     const { getByTestId, getAllByTestId, queryByTestId, getByRole, container } = result;

--- a/src/lib/components/Table/Table.test.tsx
+++ b/src/lib/components/Table/Table.test.tsx
@@ -8,10 +8,7 @@ import { t } from "./../../../utils/testUtils";
 import MotifProvider from "../../motif/context/MotifProvider";
 
 describe("Table", () => {
-  const cols = [
-    { title: "Test Title", dataKey: "testData", sorting: {} },
-    { title: "Şehir", dataKey: "city", filter: true },
-  ];
+  const cols = [{ title: "Test Title", dataKey: "testData", sorting: {} }];
   const data = [{ testData: "M Test" }, { testData: "A Test" }, { testData: "Z Test" }];
   const renderExt = (ui: ReactNode) => {
     const result = render(ui);
@@ -1104,12 +1101,12 @@ describe("Table", () => {
       ü: "ÜRGÜP",
       Ü: "ÜRGÜP",
     };
-
+    const localeCols = [{ title: "Şehir", dataKey: "city", filter: true }];
     const localeData = cities.map((city, i) => ({ testData: `Row ${i + 1}`, city }));
     for (const locale of ["tr", "en"] as const) {
       const { getFilterableTableInput, getColumnFilterInputs, unmount } = renderExt(
         <MotifProvider locale={locale}>
-          <Table columns={cols} data={localeData} filterableTable />
+          <Table columns={localeCols} data={localeData} filterableTable />
         </MotifProvider>,
       );
 

--- a/src/lib/components/Table/Table.test.tsx
+++ b/src/lib/components/Table/Table.test.tsx
@@ -1091,21 +1091,43 @@ describe("Table", () => {
     expect(getColumnFilterInputs()[0]).toHaveAttribute("placeholder", namePlaceholder);
   });
 
-  it("should match uppercase İSTANBUL when searching istanbul with locale=tr", async () => {
-    const { getFilterableTableInput } = renderExt(<Table columns={cols} data={data} filterableTable />);
-    await userEvent.type(getFilterableTableInput(), "istanbul");
-    expect(screen.getByText("İSTANBUL")).toBeInTheDocument();
-    expect(screen.queryByText("BERLİN")).not.toBeInTheDocument();
-  });
+  it("should apply locale-aware filtering in both global and column based search inputs", async () => {
+    // 'i' is omitted: İ, ı, I all normalize to 'i', so the İ case already covers bidirectional matching
+    const chars = ["İ", "ı", "I", "ö", "Ö", "ü", "Ü"];
+    const cities = ["ISPARTA", "SÖKE", "ÜRGÜP"];
+    const charExpectedCity: Record<string, string> = {
+      İ: "ISPARTA",
+      ı: "ISPARTA",
+      I: "ISPARTA",
+      ö: "SÖKE",
+      Ö: "SÖKE",
+      ü: "ÜRGÜP",
+      Ü: "ÜRGÜP",
+    };
 
-  it("should match uppercase BERLİN when searching berlin with locale=en", async () => {
-    const { getFilterableTableInput } = renderExt(
-      <MotifProvider locale="en">
-        <Table columns={cols} data={data} filterableTable />
-      </MotifProvider>,
-    );
-    await userEvent.type(getFilterableTableInput(), "berlin");
-    expect(screen.getByText("BERLİN")).toBeInTheDocument();
-    expect(screen.queryByText("İSTANBUL")).not.toBeInTheDocument();
+    const localeData = cities.map((city, i) => ({ testData: `Row ${i + 1}`, city }));
+    for (const locale of ["tr", "en"] as const) {
+      const { getFilterableTableInput, getColumnFilterInputs, unmount } = renderExt(
+        <MotifProvider locale={locale}>
+          <Table columns={cols} data={localeData} filterableTable />
+        </MotifProvider>,
+      );
+
+      const globalInput = getFilterableTableInput();
+      const columnInput = getColumnFilterInputs()[0];
+
+      for (const char of chars) {
+        await userEvent.clear(columnInput);
+        await userEvent.type(columnInput, char);
+        expect(screen.getByText(charExpectedCity[char])).toBeInTheDocument();
+      }
+      await userEvent.clear(columnInput);
+
+      await userEvent.type(globalInput, "İ");
+      expect(screen.getByText("ISPARTA")).toBeInTheDocument();
+      expect(screen.queryByText("SÖKE")).not.toBeInTheDocument();
+
+      unmount();
+    }
   });
 });

--- a/src/lib/components/Table/TableContext.tsx
+++ b/src/lib/components/Table/TableContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, PropsWithChildren, useCallback, useEffect, useMemo, useState } from "react";
-import { getNextItemInArray, getTextFromNode, getValueByChainedKey } from "../../../utils/utils";
+import { foldNormalize, getNextItemInArray, getTextFromNode, getValueByChainedKey } from "../../../utils/utils";
 import { sortByType, SORT_DIRECTIONS, getSpannedCellsMap } from "@/components/Table/helper";
 import { ColumState, RowDetail, TableContextDefaultValues, TableContextProps, TableContextType } from "@/components/Table/types";
 import { useMotifContext } from "../../motif/context/MotifProvider";
@@ -10,7 +10,7 @@ export const TableContext = createContext<TableContextType>(TableContextDefaultV
 
 export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
   const { locale } = useMotifContext();
-  const localeLower = useCallback((s: string) => caseNormalize(s, locale), [locale]);
+  const normalize = useCallback((s: string) => foldNormalize(s, locale), [locale]);
   const {
     dataRaw,
     columns,
@@ -27,8 +27,6 @@ export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
 
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [mainFilterQuery, setMainFilterQuery] = useState<string>("");
-  const caseNormalize = (s: string, locale: string): string =>
-    `${s}`.normalize("NFC").toLocaleLowerCase(locale).replace(/̇/g, "").replace(/ı/g, "i");
 
   const mapDataToMotifTableRow: (row: object, index: number) => RowDetail = useCallback(
     (row: object, index: number) => ({
@@ -52,14 +50,14 @@ export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
         const data = getValueByChainedKey<never>(row.data, column.dataKey);
         const contentToBeSearched = !column.render ? data : getTextFromNode(column.render(data));
         const columnQuery = columnStates[index]?.filterQuery;
-        return columnQuery ? !localeLower(contentToBeSearched).includes(localeLower(columnQuery)) : false;
+        return columnQuery ? !normalize(contentToBeSearched).includes(normalize(columnQuery)) : false;
       });
 
       const mainFilterMatches = mainFilterQuery
         ? columns.some(column => {
             const data = getValueByChainedKey<never>(row.data, column.dataKey);
             const contentToBeSearched = !column.render ? data : getTextFromNode(column.render(data));
-            return localeLower(contentToBeSearched).includes(localeLower(mainFilterQuery));
+            return normalize(contentToBeSearched).includes(normalize(mainFilterQuery));
           })
         : true;
 
@@ -77,7 +75,7 @@ export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
           })
         : acc;
     }, filteredRows);
-  }, [originalRows, columnStates, columns, mainFilterQuery, localeLower]);
+  }, [originalRows, columnStates, columns, mainFilterQuery, normalize]);
 
   // Data that is visible in the table. It can be less than usableRows if pagination is enabled.
   const visibleRows = useMemo(

--- a/src/lib/components/Table/TableContext.tsx
+++ b/src/lib/components/Table/TableContext.tsx
@@ -10,7 +10,6 @@ export const TableContext = createContext<TableContextType>(TableContextDefaultV
 
 export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
   const { locale } = useMotifContext();
-  const normalize = useCallback((s: string) => foldNormalize(s, locale), [locale]);
   const {
     dataRaw,
     columns,
@@ -45,19 +44,23 @@ export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
   const usableRows = useMemo(() => {
     if (!originalRows) return undefined;
 
+    const normalize = (s: string) => foldNormalize(s, locale);
+    const normalizedMainQuery = mainFilterQuery && normalize(mainFilterQuery);
+    const normalizedColumnQueries = columnStates.map(s => s.filterQuery && normalize(s.filterQuery));
+
     const filteredRows = originalRows.filter(row => {
       const columnMatches = !columns.some((column, index) => {
         const data = getValueByChainedKey<never>(row.data, column.dataKey);
         const contentToBeSearched = !column.render ? data : getTextFromNode(column.render(data));
-        const columnQuery = columnStates[index]?.filterQuery;
-        return columnQuery ? !normalize(contentToBeSearched).includes(normalize(columnQuery)) : false;
+        const columnQuery = normalizedColumnQueries[index];
+        return !!columnQuery && !normalize(contentToBeSearched).includes(columnQuery);
       });
 
-      const mainFilterMatches = mainFilterQuery
+      const mainFilterMatches = normalizedMainQuery
         ? columns.some(column => {
             const data = getValueByChainedKey<never>(row.data, column.dataKey);
             const contentToBeSearched = !column.render ? data : getTextFromNode(column.render(data));
-            return normalize(contentToBeSearched).includes(normalize(mainFilterQuery));
+            return normalize(contentToBeSearched).includes(normalizedMainQuery);
           })
         : true;
 
@@ -75,7 +78,7 @@ export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
           })
         : acc;
     }, filteredRows);
-  }, [originalRows, columnStates, columns, mainFilterQuery, normalize]);
+  }, [originalRows, columnStates, columns, mainFilterQuery, locale]);
 
   // Data that is visible in the table. It can be less than usableRows if pagination is enabled.
   const visibleRows = useMemo(

--- a/src/lib/components/Table/TableContext.tsx
+++ b/src/lib/components/Table/TableContext.tsx
@@ -4,10 +4,13 @@ import { createContext, PropsWithChildren, useCallback, useEffect, useMemo, useS
 import { getNextItemInArray, getTextFromNode, getValueByChainedKey } from "../../../utils/utils";
 import { sortByType, SORT_DIRECTIONS, getSpannedCellsMap } from "@/components/Table/helper";
 import { ColumState, RowDetail, TableContextDefaultValues, TableContextProps, TableContextType } from "@/components/Table/types";
+import { useMotifContext } from "../../motif/context/MotifProvider";
 
 export const TableContext = createContext<TableContextType>(TableContextDefaultValues);
 
 export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
+  const { locale } = useMotifContext();
+  const localeLower = useCallback((s: string) => caseNormalize(s, locale), [locale]);
   const {
     dataRaw,
     columns,
@@ -24,6 +27,8 @@ export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
 
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [mainFilterQuery, setMainFilterQuery] = useState<string>("");
+  const caseNormalize = (s: string, locale: string): string =>
+    `${s}`.normalize("NFC").toLocaleLowerCase(locale).replace(/̇/g, "").replace(/ı/g, "i");
 
   const mapDataToMotifTableRow: (row: object, index: number) => RowDetail = useCallback(
     (row: object, index: number) => ({
@@ -47,14 +52,14 @@ export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
         const data = getValueByChainedKey<never>(row.data, column.dataKey);
         const contentToBeSearched = !column.render ? data : getTextFromNode(column.render(data));
         const columnQuery = columnStates[index]?.filterQuery;
-        return columnQuery ? `${contentToBeSearched}`.toLowerCase().search(columnQuery) === -1 : false;
+        return columnQuery ? !localeLower(contentToBeSearched).includes(localeLower(columnQuery)) : false;
       });
 
       const mainFilterMatches = mainFilterQuery
         ? columns.some(column => {
             const data = getValueByChainedKey<never>(row.data, column.dataKey);
             const contentToBeSearched = !column.render ? data : getTextFromNode(column.render(data));
-            return `${contentToBeSearched}`.toLowerCase().search(mainFilterQuery) > -1;
+            return localeLower(contentToBeSearched).includes(localeLower(mainFilterQuery));
           })
         : true;
 
@@ -72,7 +77,7 @@ export const TableProvider = (props: PropsWithChildren<TableContextProps>) => {
           })
         : acc;
     }, filteredRows);
-  }, [originalRows, columnStates, columns, mainFilterQuery]);
+  }, [originalRows, columnStates, columns, mainFilterQuery, localeLower]);
 
   // Data that is visible in the table. It can be less than usableRows if pagination is enabled.
   const visibleRows = useMemo(

--- a/src/lib/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/lib/components/Table/__snapshots__/Table.test.tsx.snap
@@ -33,6 +33,38 @@ exports[`Table should render with only required props 1`] = `
               </button>
             </div>
           </th>
+          <th>
+            <div
+              class="thContent"
+            >
+              <span>
+                Şehir
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="trColumnFilters"
+        >
+          <th />
+          <th>
+            <div
+              class="thFilterContent"
+            >
+              <div
+                class="Root sm"
+                data-testid="inputItem"
+              >
+                <div
+                  class="inputWrapper"
+                >
+                  <input
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </th>
         </tr>
       </thead>
       <tbody
@@ -42,16 +74,23 @@ exports[`Table should render with only required props 1`] = `
           <td>
             M Test
           </td>
+          <td>
+            İSTANBUL
+          </td>
         </tr>
         <tr>
           <td>
             A Test
+          </td>
+          <td>
+            BERLİN
           </td>
         </tr>
         <tr>
           <td>
             Z Test
           </td>
+          <td />
         </tr>
       </tbody>
       <tfoot

--- a/src/lib/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/lib/components/Table/__snapshots__/Table.test.tsx.snap
@@ -74,17 +74,13 @@ exports[`Table should render with only required props 1`] = `
           <td>
             M Test
           </td>
-          <td>
-            İSTANBUL
-          </td>
+          <td />
         </tr>
         <tr>
           <td>
             A Test
           </td>
-          <td>
-            BERLİN
-          </td>
+          <td />
         </tr>
         <tr>
           <td>

--- a/src/lib/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/lib/components/Table/__snapshots__/Table.test.tsx.snap
@@ -33,38 +33,6 @@ exports[`Table should render with only required props 1`] = `
               </button>
             </div>
           </th>
-          <th>
-            <div
-              class="thContent"
-            >
-              <span>
-                Şehir
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="trColumnFilters"
-        >
-          <th />
-          <th>
-            <div
-              class="thFilterContent"
-            >
-              <div
-                class="Root sm"
-                data-testid="inputItem"
-              >
-                <div
-                  class="inputWrapper"
-                >
-                  <input
-                    value=""
-                  />
-                </div>
-              </div>
-            </div>
-          </th>
         </tr>
       </thead>
       <tbody
@@ -74,19 +42,16 @@ exports[`Table should render with only required props 1`] = `
           <td>
             M Test
           </td>
-          <td />
         </tr>
         <tr>
           <td>
             A Test
           </td>
-          <td />
         </tr>
         <tr>
           <td>
             Z Test
           </td>
-          <td />
         </tr>
       </tbody>
       <tfoot

--- a/src/lib/components/Table/components/Head/FilterCell.tsx
+++ b/src/lib/components/Table/components/Head/FilterCell.tsx
@@ -16,7 +16,7 @@ const FilterCell = ({ index, colSpan, placeholder }: Props) => {
   return (
     <th {...getSpanProps(colSpan)}>
       <div className={styles.thFilterContent}>
-        <InputText size="sm" placeholder={placeholder} onChange={val => updateFilterState((val as string).toLowerCase(), index)} />
+        <InputText size="sm" placeholder={placeholder} onChange={val => updateFilterState(val as string, index)} />
       </div>
     </th>
   );

--- a/src/lib/components/Table/components/Head/HeaderRow.tsx
+++ b/src/lib/components/Table/components/Head/HeaderRow.tsx
@@ -26,7 +26,7 @@ const HeaderRow = ({ colspan, header }: Props) => {
                 className={styles.filterInput}
                 placeholder={filterPlaceholder ?? t("g.search")}
                 size="sm"
-                onChange={val => setMainFilterQuery((val as string).toLowerCase())}
+                onChange={val => setMainFilterQuery(val as string)}
               />
             )}
           </div>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -72,9 +72,9 @@ export const tryParseJsonString = <T>(text: string): T | undefined => {
 };
 
 /** Normalizes a string for case-insensitive comparison: lowercases, strips diacritics, and handles locale-specific characters (e.g. Turkish dotless-i). */
-export const foldNormalize = (s: string, locale: string): string =>
+export const foldNormalize = (s: string, locale: string) =>
   `${s}`
     .toLocaleLowerCase(locale)
     .normalize("NFKD")
     .replace(/\p{Diacritic}/gu, "")
-    .replace(/\u0131/g, "i"); // \u0131 (dotless-i) has no NFKD decomposition; fold to i only in Turkish locale
+    .replace(/\u0131/g, "i");

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -70,3 +70,11 @@ export const tryParseJsonString = <T>(text: string): T | undefined => {
     return undefined;
   }
 };
+
+/** Normalizes a string for case-insensitive comparison: lowercases, strips diacritics, and handles locale-specific characters (e.g. Turkish dotless-i). */
+export const foldNormalize = (s: string, locale: string): string =>
+  `${s}`
+    .toLocaleLowerCase(locale)
+    .normalize("NFKD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/\u0131/g, "i"); // \u0131 (dotless-i) has no NFKD decomposition; fold to i only in Turkish locale


### PR DESCRIPTION
## Description

- Replaced toLowerCase() with toLocaleLowerCase(locale) in TableContext so filter comparisons use the active locale.
- Applied this change to both global search and column filters.
- Added normalization (normalize("NFKD")), and mapped ı to i to correctly handle Turkish İ/ı characters.
## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<img width="793" height="658" alt="{40FBBCF2-0AB1-424E-B33E-6A1A7FDE45D7}" src="https://github.com/user-attachments/assets/4f2dde08-c055-436c-97b0-933fc1242aa9" />

<img width="741" height="258" alt="{53D76062-E4F9-49AC-8A85-EE700D9A0324}" src="https://github.com/user-attachments/assets/a5a47994-1431-46f2-937e-dfc5d6ee5607" />

<img width="725" height="305" alt="{3FACD5B9-7ACD-4142-B87E-0E1315604742}" src="https://github.com/user-attachments/assets/50f0f6af-3a43-4461-8709-9671247f5b3e" />
## Checklist

- [ ] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

```
const columns = [
  { title: "Ad / Name", dataKey: "ad", filter: true },
  { title: "Şehir / City", dataKey: "sehir", filter: true },
  { title: "Unvan / Title", dataKey: "unvan", filter: true },
];

const data = [
  // Türkçe — büyük/küçük karışımı
  { ad: "İBRAHİM ÇELIK", sehir: "İSTANBUL", unvan: "Müdür" },
  { ad: "Şükrü Öztürk", sehir: "ANKARA", unvan: "İşletmen" },
  { ad: "GÜNEŞ YILMAZ", sehir: "İzmir", unvan: "Uzman" },
  { ad: "GÜNEŞ YILMAZ", sehir: "İZMİR", unvan: "Uzman Yardımcısı" },
  { ad: "Çiğdem Arslan", sehir: "BURSA", unvan: "ŞEF" },
  { ad: "Işıl Doğan", sehir: "Eskişehir", unvan: "MÜDÜR YARDIMCISI" },
  // Yabancı — standart Latin, Fransızca, Almanca, İspanyolca
  { ad: "John Smith", sehir: "NEW YORK", unvan: "Manager" },
  { ad: "ÉLODIE MARTIN", sehir: "Paris", unvan: "Directrice" },
  { ad: "Müller, Hans", sehir: "MÜNCHEN", unvan: "Ingenieur" },
  { ad: "García López", sehir: "madrid", unvan: "DIRECTOR" },
  { ad: "Søren Aaberg", sehir: "Copenhagen", unvan: "Analyst" },
];

<Table columns={columns} data={data} filterableTable border="rowBorders" hoverable />

```
<!-- Closes [#EDKUI-1467]: Internal purposes only -->
