### PR TITLE
fix(Icon): inline-flex overflow issue

### DIFF
--- a/src/lib/components/Icon/Icon.module.scss
+++ b/src/lib/components/Icon/Icon.module.scss
@@ -13,6 +13,7 @@ $sizes: (("xxs", "16x"), ("xs", "18x"), ("sm", "20x"), ("md", "22x"), ("lg", "24
 
   span,
   i {
+    display: block;
     font-size: inherit !important;
     line-height: 1;
     &::before {

--- a/src/lib/components/Icon/Icon.module.scss
+++ b/src/lib/components/Icon/Icon.module.scss
@@ -4,7 +4,7 @@ $variants: "primary", "secondary", "info", "success", "warning", "danger";
 $sizes: (("xxs", "16x"), ("xs", "18x"), ("sm", "20x"), ("md", "22x"), ("lg", "24x"), ("xl", "28x"), ("xxl", "32x"));
 
 .Root {
-  display: inline-flex !important;
+  display: inline-block !important;
   vertical-align: top;
   user-select: none;
   font-size: var(--mtf-icon-size, var(--base-sizing-22x)) !important;


### PR DESCRIPTION
## Description

Using inline-flex as display prop in icons were wrong and causing overflow issues as expected. This PR fixes it

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

BEFORE

<img width="379" height="66" alt="Screenshot 2026-08-04 at 15 47 07" src="https://github.com/user-attachments/assets/23355e00-7508-4fd6-aa09-f9f1283cc61e" />

AFTER

<img width="391" height="80" alt="Screenshot 2026-08-04 at 15 47 35" src="https://github.com/user-attachments/assets/e5642700-e1bc-44f7-aaea-af14f6ae492c" />

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [x] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

Just use <Icon /> anywhere

<!-- Closes [#EDKUI-001]: Internal purposes only -->
