### PR TITLE
fix: union type for variant is created

### DIFF
--- a/src/lib/components/Avatar/types.ts
+++ b/src/lib/components/Avatar/types.ts
@@ -1,4 +1,4 @@
-import type { IconGlobalType } from "../../types";
+import type { IconGlobalType, Variants } from "../../types";
 
 export type AvatarProps = {
   image?: string;
@@ -7,6 +7,6 @@ export type AvatarProps = {
 } & AvatarDefaultableProps;
 
 export type AvatarDefaultableProps = {
-  variant?: "primary" | "secondary" | "danger" | "warning" | "info" | "success";
+  variant?: Variants;
   size?: "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
 };

--- a/src/lib/components/Badge/types.ts
+++ b/src/lib/components/Badge/types.ts
@@ -1,7 +1,7 @@
-import type { IconGlobalType } from "../../types";
+import type { IconGlobalType, Variants } from "../../types";
 
 export type BadgeProps = {
-  variant?: "primary" | "secondary" | "success" | "warning" | "danger" | "info";
+  variant?: Variants;
   content?: string;
   icon?: IconGlobalType;
   dot?: boolean;

--- a/src/lib/components/BusinessCard/types.ts
+++ b/src/lib/components/BusinessCard/types.ts
@@ -1,4 +1,4 @@
-import type { IconGlobalType } from "../../types";
+import type { IconGlobalType, Variants } from "../../types";
 import type { MouseEvent } from "react";
 
 export type BusinessCardProps = {
@@ -23,5 +23,5 @@ export type BusinessCardDefaultableProps = {
   elevated?: boolean;
   outline?: boolean;
   position?: "left" | "right" | "center";
-  variant?: "neutral" | "primary" | "secondary" | "info" | "success" | "warning" | "danger";
+  variant?: "neutral" | Variants;
 };

--- a/src/lib/components/Button/types.ts
+++ b/src/lib/components/Button/types.ts
@@ -1,4 +1,4 @@
-import type { IconGlobalType } from "../../types";
+import type { IconGlobalType, Variants } from "../../types";
 import type { MouseEvent } from "react";
 
 export type ButtonProps = {
@@ -12,7 +12,7 @@ export type ButtonProps = {
 
 export type ButtonDefaultableProps = {
   shape?: "solid" | "outline" | "textonly";
-  variant?: "primary" | "secondary" | "info" | "success" | "warning" | "danger";
+  variant?: Variants;
   size?: "xxs" | "xs" | "sm" | "md" | "lg" | "xl";
   pill?: boolean;
   fluid?: boolean;

--- a/src/lib/components/Card/components/CardHeader.tsx
+++ b/src/lib/components/Card/components/CardHeader.tsx
@@ -3,7 +3,7 @@ import Avatar from "@/components/Avatar";
 import IconButton from "@/components/IconButton";
 import { sanitizeModuleClasses } from "../../../../utils/cssUtils";
 import type { MouseEvent } from "react";
-import type { IconGlobalType } from "../../../types";
+import type { IconGlobalType, Variants } from "../../../types";
 import ImageView from "@/components/ImageView";
 
 type Props = {
@@ -14,7 +14,7 @@ type Props = {
   image?: string;
   imagePosition?: "left" | "right";
   action?: { icon: IconGlobalType; onClick: (event: MouseEvent<HTMLButtonElement>) => void };
-  variant: "primary" | "secondary" | "info" | "success" | "warning" | "danger";
+  variant: Variants;
 };
 
 const CardHeader = (props: Props) => {

--- a/src/lib/components/Card/types.ts
+++ b/src/lib/components/Card/types.ts
@@ -1,5 +1,5 @@
 import type { MouseEvent, ReactElement } from "react";
-import type { IconGlobalType } from "../../types";
+import type { IconGlobalType, Variants } from "../../types";
 import { ButtonProps } from "../Button/types";
 import { LinkProps } from "../Link/types";
 import { IconButtonProps } from "../IconButton/types";
@@ -25,6 +25,6 @@ export type CardProps = {
 export type CardDefaultableProps = {
   outlined?: boolean;
   elevated?: boolean;
-  variant?: "primary" | "secondary" | "info" | "success" | "warning" | "danger";
+  variant?: Variants;
   imagePosition?: "left" | "right";
 };

--- a/src/lib/components/Dropdown/types.ts
+++ b/src/lib/components/Dropdown/types.ts
@@ -1,6 +1,6 @@
 import type { IconGlobalType } from "../../types";
 import type { MouseEvent } from "react";
-import { Size4SM } from "../../types";
+import { Size4SM, Variants } from "../../types";
 
 export type Spacing = "withGap" | "callout" | "noSpace";
 
@@ -25,7 +25,7 @@ export type DropdownProps = {
 
 export type DropdownDefaultableProps = {
   shape?: "solid" | "textOnly";
-  variant?: "primary" | "secondary" | "success" | "danger" | "warning" | "info";
+  variant?: Variants;
   size?: Size4SM;
   pill?: boolean;
   spacing?: Spacing;

--- a/src/lib/components/Icon/types.ts
+++ b/src/lib/components/Icon/types.ts
@@ -1,4 +1,4 @@
-import { Size7 } from "../../types";
+import { Size7, Variants } from "../../types";
 
 export type IconProps = {
   iconClass?: string;
@@ -7,7 +7,7 @@ export type IconProps = {
    */
   name?: string;
   size?: Size7;
-  variant?: "primary" | "secondary" | "info" | "success" | "warning" | "danger";
+  variant?: Variants;
   className?: string;
   color?: string;
   svgColorType?: "fill" | "stroke";

--- a/src/lib/components/IconButton/types.ts
+++ b/src/lib/components/IconButton/types.ts
@@ -1,4 +1,4 @@
-import { IconGlobalType, Size7 } from "../../types";
+import { IconGlobalType, Size7, Variants } from "../../types";
 import type { MouseEvent } from "react";
 
 export type IconButtonProps = {
@@ -10,5 +10,5 @@ export type IconButtonProps = {
 
 export type IconButtonDefaultableProps = {
   size?: Size7;
-  variant?: "primary" | "secondary" | "info" | "success" | "warning" | "danger" | "negative" | "strong";
+  variant?: Variants | "negative" | "strong";
 };

--- a/src/lib/components/ProgressBar/types.ts
+++ b/src/lib/components/ProgressBar/types.ts
@@ -1,4 +1,4 @@
-import { Size5 } from "../../types";
+import { Size5, Variants } from "../../types";
 
 export type ProgressBarProps = {
   progress?: number;
@@ -7,7 +7,7 @@ export type ProgressBarProps = {
 } & ProgressBarDefaultableProps;
 
 export type ProgressBarDefaultableProps = {
-  variant?: "primary" | "success" | "warning" | "danger" | "info" | "secondary";
+  variant?: Variants;
   size?: Size5;
   indeterminate?: boolean;
   showPercentage?: boolean;

--- a/src/lib/components/ProgressCircle/types.ts
+++ b/src/lib/components/ProgressCircle/types.ts
@@ -1,4 +1,4 @@
-import { Size5 } from "../../types";
+import { Size5, Variants } from "../../types";
 
 export type ProgressCircleProps = {
   progress?: number;
@@ -7,7 +7,7 @@ export type ProgressCircleProps = {
 } & ProgressCircleDefaultableProps;
 
 export type ProgressCircleDefaultableProps = {
-  variant?: "primary" | "success" | "warning" | "danger" | "info" | "secondary";
+  variant?: Variants;
   size?: Size5;
   indeterminate?: boolean;
   showPercentage?: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,8 @@ export type Size4LG = Size3 | "xl";
 export type Size5 = "xs" | Size3 | "xl";
 export type Size7 = "xxs" | Size5 | "xxl";
 
+export type Variants = "primary" | "secondary" | "info" | "success" | "warning" | "danger";
+
 export type StandardProps = {
   className?: string;
   style?: CSSProperties;


### PR DESCRIPTION
## Description

<!-- Please describe your changes and how this PR provides a solution -->

Union type for variant is created as;

export type Variants = "primary" | "secondary" | "info" | "success" | "warning" | "danger";


There are several cases we need to discuss in advance;


<img width="827" height="214" alt="Screenshot 2026-08-11 at 10 38 25" src="https://github.com/user-attachments/assets/6322f081-6ab2-4523-87f9-39d74fcfe327" />

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [x] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->

<!-- Closes [#EDKUI-1234]: Internal purposes only -->
