### PR TITLE
fix(Toast): doubled variant naming is singled as danger

### DIFF
--- a/src/lib/components/Toast/Toast.test.tsx
+++ b/src/lib/components/Toast/Toast.test.tsx
@@ -89,11 +89,11 @@ describe("Toast", () => {
   });
 
   it("should be rendered in the variant given in the variant prop", () => {
-    const variants = ["secondary", "error", "warning", "info", "success"] as const;
+    const variants = ["secondary", "danger", "warning", "info", "success"] as const;
 
     variants.forEach((variant, i) => {
       render(<Toaster content={content} variant={variant} />);
-      expect(screen.getAllByTestId("toast")[i]).toHaveClass(variant === "error" ? "danger" : variant);
+      expect(screen.getAllByTestId("toast")[i]).toHaveClass(variant);
     });
   });
 

--- a/src/lib/components/Toast/Toast.tsx
+++ b/src/lib/components/Toast/Toast.tsx
@@ -11,22 +11,7 @@ import { sanitizeModuleRootClasses } from "src/utils/cssUtils.ts";
 import ProgressBar from "@/components/ProgressBar";
 
 const Toast = (props: PropsWithRef<ToastProps, HTMLDivElement>) => {
-  const {
-    variant: toastVariant,
-    title,
-    content,
-    duration,
-    closable,
-    icon,
-    onDismiss,
-    position,
-    maxContentLength,
-    ref,
-    id,
-    style,
-    className,
-  } = props;
-  const variant = toastVariant === "error" ? "danger" : toastVariant;
+  const { variant, title, content, duration, closable, icon, onDismiss, position, maxContentLength, ref, id, style, className } = props;
 
   const [dismissed, setDismissed] = useState(false);
   const [closing, setClosing] = useState(false);

--- a/src/lib/components/Toast/types.ts
+++ b/src/lib/components/Toast/types.ts
@@ -4,7 +4,7 @@ import { PropsWithRef } from "../../types";
 
 export type ToastPosition = "topLeft" | "topRight" | "top" | "bottomLeft" | "bottomRight" | "bottom";
 
-export type ToastVariant = "secondary" | "error" | "warning" | "info" | "success";
+export type ToastVariant = "secondary" | "danger" | "warning" | "info" | "success";
 
 export type ToastProps = {
   id: string;

--- a/src/lib/components/Toast/useToast.tsx
+++ b/src/lib/components/Toast/useToast.tsx
@@ -56,7 +56,7 @@ export const useToast: () => UseToastProps = () => {
     success: createToast("success"),
     warning: createToast("warning"),
     info: createToast("info"),
-    error: createToast("error"),
+    danger: createToast("danger"),
     secondary: createToast("secondary"),
     toasts: (
       <>


### PR DESCRIPTION
## Description

Variant doubled naming issue is solved with the convention of error to danger.

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [x] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<!-- Before/After screenshots/recordings or links if applicable -->

## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [x] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->

```code
"use client";

import { useMotifContext } from "../lib/motif/context/MotifProvider";
import { useToast } from "@/components/Toast";
import Button from "@/components/Button";

const Home = () => {
  const { t } = useMotifContext();
  const toast = useToast();
  return (
    <div style={{ margin: "0 auto", padding: 20 }}>
      <h2>{t("g.hello_x", { name: "MOTİF UI" })}</h2>
      <h4>{t("misc.playgroundDescription")}</h4>
      <Button variant="danger" onClick={() => toast.danger("Toast content")} label="Warning" />
      {toast.toasts}
    </div>
  );
};

export default Home;

```

<!-- Closes [#EDKUI-1272]: Internal purposes only -->
