### PR TITLE
fix(UploadInput): add download button for pre-uploaded files

### DIFF
--- a/src/lib/components/Upload/UploadInput/UploadInput.module.scss
+++ b/src/lib/components/Upload/UploadInput/UploadInput.module.scss
@@ -159,14 +159,10 @@ $sizes: (("xs", "4x", "4x", "10x"), ("sm", "6x", "6x", "12x"), ("md", "8x", "8x"
     .label {
       @include font("body", $size);
       padding: var(--base-sizing-#{$paddingV}) var(--base-sizing-#{$paddingH});
-      &.hasSuffix {
-        padding-right: calc(3 * var(--base-sizing-#{$paddingH}));
-      }
-      &.hasSuffixes {
-        padding-right: calc(5 * var(--base-sizing-#{$paddingH}));
-      }
-      &.hasThreeSuffixes {
-        padding-right: calc(7 * var(--base-sizing-#{$paddingH}));
+      @for $i from 1 through 3 {
+        &.hasSuffix_#{$i} {
+          padding-right: calc(#{2 * $i + 1} * var(--base-sizing-#{$paddingH}));
+        }
       }
     }
     .labelSuffixWrapper {

--- a/src/lib/components/Upload/UploadInput/UploadInput.module.scss
+++ b/src/lib/components/Upload/UploadInput/UploadInput.module.scss
@@ -165,6 +165,9 @@ $sizes: (("xs", "4x", "4x", "10x"), ("sm", "6x", "6x", "12x"), ("md", "8x", "8x"
       &.hasSuffixes {
         padding-right: calc(5 * var(--base-sizing-#{$paddingH}));
       }
+      &.hasThreeSuffixes {
+        padding-right: calc(7 * var(--base-sizing-#{$paddingH}));
+      }
     }
     .labelSuffixWrapper {
       right: var(--base-sizing-#{$paddingH});

--- a/src/lib/components/Upload/UploadInput/UploadInput.test.tsx
+++ b/src/lib/components/Upload/UploadInput/UploadInput.test.tsx
@@ -21,6 +21,8 @@ describe("UploadInput", () => {
 
     const getDeleteButton = () => screen.queryByText("delete") as HTMLButtonElement;
 
+    const getDownloadButton = () => screen.queryByText("download") as HTMLButtonElement;
+
     const getUploadButton = () => screen.queryByText(t("g.upload")) as HTMLButtonElement;
 
     const getBrowseButton = () => screen.queryByText(t("g.browse")) as HTMLButtonElement;
@@ -60,6 +62,7 @@ describe("UploadInput", () => {
       getFileItem,
       getErrorIcon,
       getDeleteButton,
+      getDownloadButton,
       getUploadButton,
       getBrowseButton,
       actHoverToErrorIcon,
@@ -486,5 +489,61 @@ describe("UploadInput", () => {
     rerender(<UploadInput {...requiredProps} value={[serverFile2]} />);
     expect(getFileItem()).toHaveTextContent(serverFile2.name);
     expect(getFileItem()).not.toHaveTextContent(serverFile.name);
+  });
+
+  it("should render the download button when onDownloadClick is provided in value", () => {
+    const { unmount, getDownloadButton } = renderExt(<UploadInput {...requiredProps} value={[serverFile]} />);
+    expect(getDownloadButton()).not.toBeInTheDocument();
+    unmount();
+    renderExt(<UploadInput {...requiredProps} value={[{ ...serverFile, onDownloadClick: jest.fn() }]} />);
+    expect(getDownloadButton()).toBeInTheDocument();
+  });
+
+  it("should call onDownloadClick when the download button is clicked", async () => {
+    const onDownloadClick = jest.fn();
+    const { getDownloadButton } = renderExt(<UploadInput {...requiredProps} value={[{ ...serverFile, onDownloadClick }]} />);
+    await userEvent.click(getDownloadButton());
+    expect(onDownloadClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onDownloadClick for all files when the download button is clicked with multiple value files", async () => {
+    const onDownloadClick1 = jest.fn();
+    const onDownloadClick2 = jest.fn();
+    const { getDownloadButton } = renderExt(
+      <UploadInput
+        {...requiredProps}
+        maxFile={2}
+        value={[
+          { ...serverFile, onDownloadClick: onDownloadClick1 },
+          { ...serverFile2, onDownloadClick: onDownloadClick2 },
+        ]}
+      />,
+    );
+    await userEvent.click(getDownloadButton());
+    expect(onDownloadClick1).toHaveBeenCalledTimes(1);
+    expect(onDownloadClick2).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show the download button but hide the delete button when disabled or readOnly", () => {
+    const { unmount, getDownloadButton, getDeleteButton } = renderExt(
+      <UploadInput {...requiredProps} value={[{ ...serverFile, onDownloadClick: jest.fn() }]} disabled />,
+    );
+    expect(getDownloadButton()).toBeInTheDocument();
+    expect(getDeleteButton()).not.toBeInTheDocument();
+    unmount();
+
+    renderExt(<UploadInput {...requiredProps} value={[{ ...serverFile, onDownloadClick: jest.fn() }]} readOnly />);
+    expect(getDownloadButton()).toBeInTheDocument();
+    expect(getDeleteButton()).not.toBeInTheDocument();
+  });
+
+  it("should not show download button after value file is deleted", async () => {
+    const xhrSpy = mockXHRs(200);
+    const { getDownloadButton, getDeleteButton } = renderExt(
+      <UploadInput {...requiredProps} value={[{ ...serverFile, onDownloadClick: jest.fn() }]} />,
+    );
+    await userEvent.click(getDeleteButton());
+    await waitFor(() => expect(getDownloadButton()).not.toBeInTheDocument());
+    xhrSpy.mockRestore();
   });
 });

--- a/src/lib/components/Upload/UploadInput/components/LabelArea.tsx
+++ b/src/lib/components/Upload/UploadInput/components/LabelArea.tsx
@@ -42,8 +42,9 @@ export const LabelArea = (props: Props) => {
 
   const suffixType: LabelSuffix = errors?.length ? "errorTooltip" : error ? "error" : success ? "success" : null;
   const enableDelete = !disabled && (!!errors?.length || (inputState !== "noFile" && inputState !== "uploading"));
+  const enableDownload = !noFiles && selectedFiles.some(f => !!f.download);
   const buttonDisabled = disabled || (inputState !== "noFile" && inputState !== "uploading");
-  const numberOfSuffixes = (suffixType ? 1 : 0) + (enableDelete ? 1 : 0);
+  const numberOfSuffixes = (suffixType ? 1 : 0) + (enableDelete ? 1 : 0) + (enableDownload ? 1 : 0);
 
   const wrapperClassNames = sanitizeModuleClasses(
     styles,
@@ -57,7 +58,7 @@ export const LabelArea = (props: Props) => {
     "label",
     noFiles && "placeholder",
     (autoUpload || noFiles) && "roundedEnd",
-    numberOfSuffixes === 1 ? "hasSuffix" : numberOfSuffixes === 2 && "hasSuffixes",
+    numberOfSuffixes === 1 ? "hasSuffix" : numberOfSuffixes === 2 ? "hasSuffixes" : numberOfSuffixes === 3 && "hasThreeSuffixes",
   );
   return (
     <div className={wrapperClassNames}>
@@ -68,7 +69,7 @@ export const LabelArea = (props: Props) => {
           <button className={classNames} onClick={browse} disabled={buttonDisabled} type="button">
             {text}
           </button>
-          <LabelSuffix size={size} errors={errors} labelSuffix={suffixType} enableDelete={enableDelete} />
+          <LabelSuffix size={size} errors={errors} labelSuffix={suffixType} enableDelete={enableDelete} enableDownload={enableDownload} />
         </>
       )}
     </div>

--- a/src/lib/components/Upload/UploadInput/components/LabelArea.tsx
+++ b/src/lib/components/Upload/UploadInput/components/LabelArea.tsx
@@ -42,7 +42,7 @@ export const LabelArea = (props: Props) => {
 
   const suffixType: LabelSuffix = errors?.length ? "errorTooltip" : error ? "error" : success ? "success" : null;
   const enableDelete = !disabled && (!!errors?.length || (inputState !== "noFile" && inputState !== "uploading"));
-  const enableDownload = !noFiles && selectedFiles.some(f => !!f.download);
+  const enableDownload = selectedFiles.some(f => !!f.download);
   const buttonDisabled = disabled || (inputState !== "noFile" && inputState !== "uploading");
   const numberOfSuffixes = (suffixType ? 1 : 0) + (enableDelete ? 1 : 0) + (enableDownload ? 1 : 0);
 
@@ -58,7 +58,7 @@ export const LabelArea = (props: Props) => {
     "label",
     noFiles && "placeholder",
     (autoUpload || noFiles) && "roundedEnd",
-    numberOfSuffixes === 1 ? "hasSuffix" : numberOfSuffixes === 2 ? "hasSuffixes" : numberOfSuffixes === 3 && "hasThreeSuffixes",
+    numberOfSuffixes > 0 && `hasSuffix_${numberOfSuffixes}`,
   );
   return (
     <div className={wrapperClassNames}>

--- a/src/lib/components/Upload/UploadInput/components/LabelSuffix.tsx
+++ b/src/lib/components/Upload/UploadInput/components/LabelSuffix.tsx
@@ -10,17 +10,22 @@ type Props = {
   errors?: string[];
   labelSuffix: LabelSuffix;
   enableDelete?: boolean;
+  enableDownload?: boolean;
 };
 
 export type LabelSuffix = "error" | "errorTooltip" | "success" | null;
 
 export const LabelSuffix = memo((props: Props) => {
-  const { size, errors, labelSuffix, enableDelete } = props;
+  const { size, errors, labelSuffix, enableDelete, enableDownload } = props;
   const { removeFiles, selectedFiles } = useContext(UploadContext);
   const isDeleting = selectedFiles.some(f => f.deleting);
+  const downloadAll = () => selectedFiles.forEach(f => f.download?.());
 
   return (
     <div className={styles.labelSuffixWrapper}>
+      {enableDownload && (
+        <MotifIconButton onClick={downloadAll} name="download" size={size} className={`${styles.labelSuffix} ${styles.focusable}`} />
+      )}
       {enableDelete && (
         <MotifIconButton
           onClick={() => removeFiles(selectedFiles)}

--- a/src/lib/components/Upload/UploadInput/components/LabelSuffix.tsx
+++ b/src/lib/components/Upload/UploadInput/components/LabelSuffix.tsx
@@ -9,8 +9,8 @@ type Props = {
   size: InputSize;
   errors?: string[];
   labelSuffix: LabelSuffix;
-  enableDelete?: boolean;
-  enableDownload?: boolean;
+  enableDelete: boolean;
+  enableDownload: boolean;
 };
 
 export type LabelSuffix = "error" | "errorTooltip" | "success" | null;


### PR DESCRIPTION
## Description

- Added a download button to UploadInput for files provided via the value prop, consistent with the existing onDownloadClick pattern used in UploadList and UploadDragger
- When multiple files are present, clicking the single download button triggers all files' onDownloadClick callbacks
- Download button remains visible in disabled and readOnly modes , only the delete button is hidden, matching the FileButton behavior in list/dragger variants
- Added tests covering: visibility with/without onDownloadClick, click behavior for single and multiple files, disabled/readOnly states, and post-delete cleanup

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [x] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<img width="500" height="706" alt="{3DCF237D-AABE-4DEF-BCCE-B0DFC72F06D2}" src="https://github.com/user-attachments/assets/5382ca8b-0ab2-4654-bcab-98bb9e7a83cb" />

## Checklist

- [ ] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test


```
`const preloadedFiles: FileObject[] = [
  {
    id: "file-1",
    name: "rapor-2024.pdf",
    size: 204800,
    type: "application/pdf",
    onDownloadClick: () => alert("rapor-2024.pdf indiriliyor..."),
  },
];

const preloadedFilesNoDownload: FileObject[] = [
  {
    id: "file-2",
    name: "belge.docx",
    size: 51200,
    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
  },
];

const multipleFiles: FileObject[] = [
  {
    id: "file-3",
    name: "tablo.xlsx",
    size: 102400,
    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
    onDownloadClick: () => alert("tablo.xlsx indiriliyor..."),
  },
  {
    id: "file-4",
    name: "sunum.pptx",
    size: 512000,
    type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
    onDownloadClick: () => alert("sunum.pptx indiriliyor..."),
  },
];

const requestConfig = {
  uploadRequest: { url: "https://httpbin.org/post", method: "POST" as const },
  deleteRequest: { url: "https://httpbin.org/delete", method: "DELETE" as const },
};`
```

```
      <p style={{ marginBottom: 4 }}>Tek dosya, onDownloadClick ile (download butonu görünmeli):</p>
      <UploadInput {...requestConfig} value={preloadedFiles} />
      <p style={{ marginBottom: 4 }}>Tek dosya, disabled</p>
      <UploadInput {...requestConfig} value={preloadedFiles} disabled />

      <p style={{ marginTop: 20, marginBottom: 4 }}>Tek dosya, onDownloadClick olmadan (download butonu görünmemeli):</p>
      <UploadInput {...requestConfig} value={preloadedFilesNoDownload} readOnly />
      <p style={{ marginTop: 20, marginBottom: 4 }}>Tek dosya, readonly</p>

      <UploadInput {...requestConfig} value={preloadedFilesNoDownload} />

      <p style={{ marginTop: 20, marginBottom: 4 }}>Çoklu dosya, hepsinde onDownloadClick var:</p>
      <UploadInput {...requestConfig} maxFile={2} value={multipleFiles} />

      <p style={{ marginTop: 20, marginBottom: 4 }}>3 suffix — download + delete + success ikonu (tüm sizeler):</p>
      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
        <UploadInput {...requestConfig} value={preloadedFiles} success size="xs" />
        <UploadInput {...requestConfig} value={preloadedFiles} success size="sm" />
        <UploadInput {...requestConfig} value={preloadedFiles} success size="md" />
        <UploadInput {...requestConfig} value={preloadedFiles} success size="lg" />
```

<!-- Closes [#EDKUI-1479]: Internal purposes only -->
