### PR TITLE
refactor: i18n plural rules, docs and tests

### DIFF
--- a/src/docs/v1/gettingStarted/localization.mdx
+++ b/src/docs/v1/gettingStarted/localization.mdx
@@ -101,6 +101,29 @@ const frenchTexts: DeepPartial<LocaleShape> = {
 
 > `LocaleShape` is the full type of a locale file. `DeepPartial<LocaleShape>` makes every key optional, so you only need to supply the strings you want to change.
 
+## Pluralization
+
+Pass a numeric `count` in the params object and the matching plural form is selected automatically, using the same [CLDR plural rules](https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html) `Intl.PluralRules` resolves (the same mechanism `i18next` uses internally). Define plural forms by suffixing a key with the CLDR category — `_one`, `_few`, `_many`, `_two`, `_zero` — and leave the base key as the `_other` form:
+
+```json
+{
+  "upload": {
+    "filesBeingUploaded": "Files are being uploaded...",
+    "filesBeingUploaded_one": "File is being uploaded..."
+  }
+}
+```
+
+```tsx
+t("upload.filesBeingUploaded", { count: 1 }); // "File is being uploaded..."
+t("upload.filesBeingUploaded", { count: 3 }); // "Files are being uploaded..."
+
+```
+
+This works the same way for overrides passed via `texts` and for keys in a fully custom locale. If a locale is missing a plural form, resolution falls back to the built-in locale's plural form, then to English's, then to the base key — the same override → locale → English chain used for every other key.
+
+> Because this follows the exact \_one/\_other suffix convention i18next uses, locale JSON written for the built-in translator is also valid i18next resource data — no rework needed if you later switch to passing your own t.
+
 ## Integrating an External i18n Library
 
 If your project already uses a library like `react-i18next`, you can pass your own `t` function to `MotifProvider`. The library will use it instead of its built-in translations — no global i18n instance is touched and there are no conflicts between the two.

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -54,7 +54,7 @@
     "deleteError": "Dosya silinirken bir hata oluştu. Lütfen tekrar deneyiniz.",
     "pleaseDrop": "Yüklemek istediğiniz dosyaları buraya bırakın.",
     "pleaseDrop_one": "Yüklemek istediğiniz dosyayı buraya bırakın.",
-    "pleaseClickOrDrop": "Dosya yüklemek için bu alana tıklayın veya dosyaları buraya bırakın.",
+    "pleaseClickOrDrop": "Dosyaları yüklemek için bu alana tıklayın veya dosyaları buraya bırakın.",
     "pleaseClickOrDrop_one": "Dosya yüklemek için bu alana tıklayın veya dosyayı buraya bırakın.",
     "filesBeingUploaded": "Dosyalar yükleniyor...",
     "filesBeingUploaded_one": "Dosya yükleniyor...",

--- a/src/i18n/localization.test.tsx
+++ b/src/i18n/localization.test.tsx
@@ -292,4 +292,37 @@ describe("Localization", () => {
       expect(typeof t(key as Parameters<typeof t>[0])).toBe("string");
     });
   });
+  it("should use the singular form when count is 1", () => {
+    const t = createTranslator("en");
+    expect(t("upload.filesBeingUploaded", { count: 1 })).toBe(en.upload.filesBeingUploaded_one);
+  });
+
+  it("should use the base key as the plural form when count is not 1", () => {
+    const t = createTranslator("en");
+    expect(t("upload.filesBeingUploaded", { count: 3 })).toBe(en.upload.filesBeingUploaded);
+  });
+
+  it("should resolve the correct plural form for Turkish", () => {
+    const t = createTranslator("tr");
+    expect(t("upload.pleaseDrop", { count: 1 })).toBe(tr.upload.pleaseDrop_one);
+    expect(t("upload.pleaseDrop", { count: 5 })).toBe(tr.upload.pleaseDrop);
+  });
+
+  it("should ignore pluralization when count is not provided", () => {
+    const t = createTranslator("en");
+    expect(t("upload.filesBeingUploaded")).toBe(en.upload.filesBeingUploaded);
+  });
+
+  it("should prefer an overridden plural form over the built-in one", () => {
+    const override = "Bir dosya yükleniyor";
+    const t = createTranslator("en", { upload: { filesBeingUploaded_one: override } });
+    expect(t("upload.filesBeingUploaded", { count: 1 })).toBe(override);
+    expect(t("upload.filesBeingUploaded", { count: 3 })).toBe(en.upload.filesBeingUploaded);
+  });
+
+  it("should fall back to the base key when no plural form exists for the key", () => {
+    const t = createTranslator("en");
+    expect(t("g.save", { count: 1 })).toBe(en.g.save);
+    expect(t("g.save", { count: 3 })).toBe(en.g.save);
+  });
 });

--- a/src/i18n/translate.ts
+++ b/src/i18n/translate.ts
@@ -25,14 +25,7 @@ const interpolate = (template: string | string[], params?: Record<string, unknow
   });
 };
 
-// Locales where Intl.PluralRules returns "other" for all counts (Turkish has no built-in singular category).
-// For these, count === 1 is explicitly mapped to "_one".
-const SINGULAR_OVERRIDE_LOCALES: readonly Locale[] = ["tr"];
-
 const getPluralSuffix = (locale: Locale, count: number): string => {
-  if (SINGULAR_OVERRIDE_LOCALES.includes(locale)) {
-    return count === 1 ? "_one" : "";
-  }
   const rule = new Intl.PluralRules(locale).select(count);
   return rule === "other" ? "" : `_${rule}`;
 };

--- a/src/lib/components/Select/helper.ts
+++ b/src/lib/components/Select/helper.ts
@@ -1,8 +1,8 @@
 import { SelectGroupItem, SelectItem, SelectOrGroupItem } from "@/components/Select/types";
 import { foldNormalize } from "../../../utils/utils";
 
-export const filterItems = (items: SelectOrGroupItem[], q: string, locale?: string) => {
-  const normalize = (s: string) => foldNormalize(s, locale ?? "en");
+export const filterItems = (items: SelectOrGroupItem[], q: string, locale: string) => {
+  const normalize = (s: string) => foldNormalize(s, locale);
   const query = normalize(q);
 
   const filterItem = (item: SelectItem) => normalize(item.label ?? item.value).includes(query);


### PR DESCRIPTION
## Description

1. Removed the `SINGULAR_OVERRIDE_LOCALES` workaround in translate.ts that manually mapped count === 1 to _one for Turkish; Intl.PluralRules now handles all locales uniformly
2. Fixed a grammatically incorrect Turkish string in tr.json: pleaseClickOrDrop base (other) form changed from "Dosya yüklemek…" to "Dosyaları yüklemek…"
3. Made locale a required parameter in Select/helper.ts, removing the ?? "en" fallback
4. Added 6 new tests covering: singular/plural selection, Turkish locale, no-count passthrough, override precedence, and base-key fallback
5. Added a Pluralization section to the localization docs explaining CLDR suffix conventions and the override → locale → English fallback chain

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [ ] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

<img width="1264" height="751" alt="image" src="https://github.com/user-attachments/assets/3e068f2e-149d-458e-bdaf-907cfbe3ac69" />

## Checklist

- [ ] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

```
<MotifProvider locale="tr">
  <UploadList {...sharedProps} name="ul-tr-1" maxFile={1} />
  <UploadList {...sharedProps} name="ul-tr-5" maxFile={5} />
  <UploadDragger {...sharedProps} name="ud-tr-1" maxFile={1} />
  <UploadDragger {...sharedProps} name="ud-tr-5" maxFile={5} />
</MotifProvider>

<MotifProvider locale="en">
  <UploadList {...sharedProps} name="ul-en-1" maxFile={1} />
  <UploadList {...sharedProps} name="ul-en-5" maxFile={5} />
  <UploadDragger {...sharedProps} name="ud-en-1" maxFile={1} />
  <UploadDragger {...sharedProps} name="ud-en-5" maxFile={5} />
</MotifProvider>
```


<!-- Brief steps for reviewers -->

<!-- Closes [#EDKUI-1473]: Internal purposes only -->
