### PR TITLE
docs(Storybook): hide form component horizontal scrollbar

### DIFF
--- a/src/lib/components/Form/Form.stories.tsx
+++ b/src/lib/components/Form/Form.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof Form> = {
     (Story, context) => (
       <div
         style={{
-          ...(context.args.formOrientation === "horizontal" ? { width: "100%", overflow: "scroll" } : { width: 500, overflow: "initial" }),
+          ...(context.args.formOrientation === "horizontal" ? { width: "100%", overflowX: "scroll" } : { width: 500, overflow: "initial" }),
           padding: 50,
           margin: "0 auto",
         }}


### PR DESCRIPTION
## Description

`Storybook Form Component (horizontal):` Changed overflow: scroll to overflowX: scroll to prevent the unnecessary vertical scrollbar from appearing on Windows. Only horizontal scrolling is enabled.
## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview

BEFORE: 
<img width="1254" height="617" alt="image" src="https://github.com/user-attachments/assets/21e7938e-f8fa-477f-a660-609a2e220ffb" />

AFTER: 
<img width="1249" height="660" alt="image" src="https://github.com/user-attachments/assets/00949e2e-bc6e-4a53-8574-89114a1bb285" />

## Checklist

- [ ] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test

<!-- Brief steps for reviewers -->

<!-- Closes [#EDKUI-1501]: Internal purposes only -->
