### PR TITLE
docs(DesignTokenNamingDiagram): fix diagram layout breaking on resize

### DIFF
--- a/.github/workflows/chromatic-ui.yml
+++ b/.github/workflows/chromatic-ui.yml
@@ -33,11 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-      - name: Checkout PR head
+      - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: '0'
           persist-credentials: 'false'
 
@@ -61,7 +59,7 @@ jobs:
 
       # --- Chromatic: Storybook build + TurboSnap ---
       - name: Run Chromatic
-        uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
+        uses: chromaui/action@2a0b63f30233c48591844a46d451b9cf68128186 # v18.7.2
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
@@ -78,7 +76,7 @@ jobs:
       #     manifest when `playwright` is combined with `onlyChanged`/`buildScriptName`) ---
       - name: Upload Playwright snapshots to Chromatic
         if: needs.detect-changes.outputs.storybook == 'true'
-        uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
+        uses: chromaui/action@2a0b63f30233c48591844a46d451b9cf68128186 # v18.7.2
         with:
           playwright: true
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/src/docs/components/DesignTokenNamingDiagram/DesignTokenNamingDiagram.module.scss
+++ b/src/docs/components/DesignTokenNamingDiagram/DesignTokenNamingDiagram.module.scss
@@ -20,8 +20,6 @@
   align-items: center;
   gap: 12px;
 
-  // Grid items default to min-width: auto, which lets the non-wrapping pill and
-  // long hint words push the track past 1fr and overflow the container.
   min-width: 0;
 }
 
@@ -34,9 +32,6 @@
   font-size: 18px;
   backdrop-filter: blur(10px);
   white-space: nowrap;
-  max-width: 100%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   * {
     color: #ffffff !important;
   }

--- a/src/docs/components/DesignTokenNamingDiagram/DesignTokenNamingDiagram.module.scss
+++ b/src/docs/components/DesignTokenNamingDiagram/DesignTokenNamingDiagram.module.scss
@@ -8,23 +8,21 @@
   border-radius: 22px;
   padding: 48px;
   margin: 32px 0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 24px 8px;
+  align-items: start;
+}
+
+.column {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0;
-  min-width: fit-content;
-}
+  gap: 12px;
 
-.tokensRow {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  flex-wrap: nowrap;
-  justify-content: center;
-  width: 100%;
-  overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: #8b5cf6 #3b82f6;
+  // Grid items default to min-width: auto, which lets the non-wrapping pill and
+  // long hint words push the track past 1fr and overflow the container.
+  min-width: 0;
 }
 
 .tokenPill {
@@ -36,33 +34,18 @@
   font-size: 18px;
   backdrop-filter: blur(10px);
   white-space: nowrap;
-  min-width: 60px;
-  flex-shrink: 0;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
   * {
     color: #ffffff !important;
   }
 }
 
-.connectingLines {
-  margin: 0;
-  overflow: visible;
-}
-
-.explanationsRow {
-  display: flex;
-  gap: 48px;
-  align-items: flex-start;
-  justify-content: center;
-  flex-wrap: nowrap;
-  max-width: 900px;
-  margin-top: 0;
-}
-
-.explanation {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
+.connector {
+  width: 0;
+  height: 32px;
+  border-left: 2px dashed rgb(255 255 255 / 40%);
 }
 
 .numberCircle {
@@ -83,9 +66,11 @@
 .explanationText {
   font-size: 14px;
   text-align: center;
-  max-width: 120px;
+  max-width: 160px;
   line-height: 1.5;
   color: #ffffff !important;
+  overflow-wrap: break-word;
+  hyphens: auto;
   strong {
     color: #ffffff !important;
   }
@@ -93,16 +78,12 @@
 
 @media (width <= 1200px) {
   .diagramContainer {
-    gap: 24px;
     padding: 40px 32px;
+    gap: 20px 8px;
   }
   .tokenPill {
     padding: 10px 20px;
     font-size: 16px;
-  }
-  .explanationsRow {
-    gap: 24px;
-    max-width: 100%;
   }
   .numberCircle {
     width: 40px;
@@ -111,30 +92,34 @@
   }
   .explanationText {
     font-size: 13px;
-    max-width: 110px;
     line-height: 1.45;
+  }
+}
+
+@media (width <= 992px) {
+  .diagramContainer {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 24px 12px;
   }
 }
 
 @media (width <= 768px) {
   .diagramContainer {
-    padding: 32px 20px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    padding: 24px 16px;
     border-radius: 12px;
     margin: 24px 0;
-    gap: 20px;
+    gap: 20px 12px;
   }
-  .tokensRow {
-    gap: 16px;
+  .column {
+    gap: 10px;
+  }
+  .connector {
+    height: 24px;
   }
   .tokenPill {
     padding: 10px 18px;
     font-size: 15px;
-  }
-  .explanationsRow {
-    gap: 20px;
-  }
-  .explanation {
-    gap: 10px;
   }
   .numberCircle {
     width: 36px;
@@ -142,39 +127,29 @@
     font-size: 16px;
     box-shadow: 0 3px 8px rgb(0 0 0 / 20%);
   }
-  .connectingLines {
-    display: none;
-  }
   .explanationText {
     font-size: 12px;
-    max-width: 100px;
     line-height: 1.4;
   }
 }
 
 @media (width <= 480px) {
   .diagramContainer {
-    padding: 24px 16px;
+    grid-template-columns: 1fr;
+    padding: 16px 12px;
     border-radius: 8px;
     margin: 16px 0;
-    gap: 16px;
+    gap: 14px;
   }
-  .tokensRow {
-    gap: 8px;
+  .column {
+    gap: 6px;
+  }
+  .connector {
+    height: 20px;
   }
   .tokenPill {
-    padding: 6px 8px;
-    font-size: 10px;
-    min-width: 50px;
-  }
-  .connectingLines {
-    display: none;
-  }
-  .explanationsRow {
-    gap: 10px;
-  }
-  .explanation {
-    gap: 8px;
+    padding: 6px 16px;
+    font-size: 13px;
   }
   .numberCircle {
     width: 28px;
@@ -183,8 +158,8 @@
     box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
   }
   .explanationText {
-    font-size: 10px;
-    max-width: 80px;
-    line-height: 1.3;
+    font-size: 11px;
+    max-width: 220px;
+    line-height: 1.35;
   }
 }

--- a/src/docs/components/DesignTokenNamingDiagram/DesignTokenNamingDiagram.module.scss
+++ b/src/docs/components/DesignTokenNamingDiagram/DesignTokenNamingDiagram.module.scss
@@ -70,7 +70,6 @@
   line-height: 1.5;
   color: #ffffff !important;
   overflow-wrap: break-word;
-  hyphens: auto;
   strong {
     color: #ffffff !important;
   }

--- a/src/docs/components/DesignTokenNamingDiagram/DesignTokenNamingDiagram.tsx
+++ b/src/docs/components/DesignTokenNamingDiagram/DesignTokenNamingDiagram.tsx
@@ -1,120 +1,49 @@
 import styles from "./DesignTokenNamingDiagram.module.scss";
 
+const TOKEN_PARTS = [
+  {
+    pill: "theme",
+    title: "Namespace",
+    hint: "(theme, base, ...)",
+  },
+  {
+    pill: "color",
+    title: "Type",
+    hint: "(color, typography, sizing, ...)",
+  },
+  {
+    pill: "surface",
+    title: "Category",
+    hint: "(text, surface, border, ...)",
+  },
+  {
+    pill: "primary",
+    title: "Family",
+    hint: "(primary, secondary, success, warning, ...)",
+  },
+  {
+    pill: "disabled",
+    title: "State/Scale",
+    hint: "(default, hover, active, 500, ...)",
+  },
+];
+
 const DesignTokenNamingDiagram = () => {
   return (
     <div className={styles.container}>
-      {/* Token Naming Convention Diagram */}
       <div className={styles.diagramContainer}>
-        {/* Token Pills */}
-        <div className={styles.tokensRow}>
-          <div className={styles.tokenPill}>theme</div>
-          <div className={styles.tokenPill}>color</div>
-          <div className={styles.tokenPill}>surface</div>
-          <div className={styles.tokenPill}>primary</div>
-          <div className={styles.tokenPill}>disabled</div>
-        </div>
-
-        {/* SVG Lines */}
-        <svg width="100%" height="110" className={styles.connectingLines} viewBox="0 0 100 110" preserveAspectRatio="none">
-          <line
-            x1="20%"
-            y1="0"
-            x2="12%"
-            y2="100"
-            stroke="rgba(255, 255, 255, 0.4)"
-            strokeWidth="2"
-            strokeDasharray="4,4"
-            vectorEffect="non-scaling-stroke"
-          />
-          <line
-            x1="34%"
-            y1="0"
-            x2="30%"
-            y2="100"
-            stroke="rgba(255, 255, 255, 0.4)"
-            strokeWidth="2"
-            strokeDasharray="4,4"
-            vectorEffect="non-scaling-stroke"
-          />
-          <line
-            x1="48%"
-            y1="0"
-            x2="49%"
-            y2="100"
-            stroke="rgba(255, 255, 255, 0.4)"
-            strokeWidth="2"
-            strokeDasharray="4,4"
-            vectorEffect="non-scaling-stroke"
-          />
-          <line
-            x1="62%"
-            y1="0"
-            x2="68%"
-            y2="100"
-            stroke="rgba(255, 255, 255, 0.4)"
-            strokeWidth="2"
-            strokeDasharray="4,4"
-            vectorEffect="non-scaling-stroke"
-          />
-          <line
-            x1="78%"
-            y1="0"
-            x2="88%"
-            y2="100"
-            stroke="rgba(255, 255, 255, 0.4)"
-            strokeWidth="2"
-            strokeDasharray="4,4"
-            vectorEffect="non-scaling-stroke"
-          />
-        </svg>
-
-        {/* Explanations */}
-        <div className={styles.explanationsRow}>
-          <div className={styles.explanation}>
-            <div className={styles.numberCircle}>1</div>
+        {TOKEN_PARTS.map(({ pill, title, hint }, index) => (
+          <div key={pill} className={styles.column}>
+            <div className={styles.tokenPill}>{pill}</div>
+            <div className={styles.connector} aria-hidden="true" />
+            <div className={styles.numberCircle}>{index + 1}</div>
             <div className={styles.explanationText}>
-              <strong>Namespace</strong>
+              <strong>{title}</strong>
               <br />
-              (theme, base, ...)
+              {hint}
             </div>
           </div>
-
-          <div className={styles.explanation}>
-            <div className={styles.numberCircle}>2</div>
-            <div className={styles.explanationText}>
-              <strong>Type</strong>
-              <br />
-              (color, typography, sizing, ...)
-            </div>
-          </div>
-
-          <div className={styles.explanation}>
-            <div className={styles.numberCircle}>3</div>
-            <div className={styles.explanationText}>
-              <strong>Category</strong>
-              <br />
-              (text, surface, border, ...)
-            </div>
-          </div>
-
-          <div className={styles.explanation}>
-            <div className={styles.numberCircle}>4</div>
-            <div className={styles.explanationText}>
-              <strong>Family</strong>
-              <br />
-              (primary, secondary, success, warning, ...)
-            </div>
-          </div>
-
-          <div className={styles.explanation}>
-            <div className={styles.numberCircle}>5</div>
-            <div className={styles.explanationText}>
-              <strong>State/Scale</strong>
-              <br />
-              (default, hover, active, 500, ...)
-            </div>
-          </div>
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/src/docs/v1/design/designTokens.mdx
+++ b/src/docs/v1/design/designTokens.mdx
@@ -27,9 +27,7 @@ Design tokens follow a structured naming pattern to ensure consistency and clari
 across design systems, though they may vary slightly from library to library. Below is the naming convention used in
 Motif UI:
 
-<div style={{ minWidth: "320px", overflowX: "auto" }}>
-  <Canvas of={DesignTokenNamingDiagram.Primary} layout="fullscreen" className="no-border story-no-margin" sourceState="none" />
-</div>
+<Canvas of={DesignTokenNamingDiagram.Primary} layout="fullscreen" className="no-border story-no-margin" sourceState="none" />
 
 Each token branches itself after each section. While color tokens have their own sub-sections, typography tokens have theirs, and so on. These possible breakdowns, samples and other related documentation are stated below.
 


### PR DESCRIPTION

## Description

- Removed the SVG dashed arrows and switched to a grid-based responsive layout — connectors now stay aligned at every width.
- Reduced padding/gap on narrow screens.
- Removed the minWidth: 320px wrapper that was forcing the docs page into horizontal scroll.

## Type of Change

<!-- Please select options that are relevant -->

- [ ] 🆕 New Component
- [ ] ✨ Feature / Enhancement
- [x] 🐛 Bug Fix
- [ ] 💥 Breaking Change
- [ ] 📦 Build / Dependency / Docs Update
- [ ] 🧹 Code Refactoring

## Screenshots / Preview
### Before

<img width="970" alt="image" src="https://github.com/user-attachments/assets/82c8920d-a9aa-40ae-8864-5635f07e91e6" />

### After
<img width="964" height="418" alt="Screenshot 2026-09-08 at 10 22 16" src="https://github.com/user-attachments/assets/1055b19e-7099-4c83-a10b-2f47302fb998" />

<img width="331" height="711" alt="Screenshot 2026-09-08 at 10 37 23" src="https://github.com/user-attachments/assets/a3033356-1f55-4fe3-b1aa-29e42f38b3a4" />


## Checklist

- [x] Self-reviewed, no leftover logs or debug code
- [ ] Uses design tokens — no hardcoded style values
- [ ] Accessible (keyboard nav, ARIA, contrast)
- [ ] Tests added/updated and passing
- [ ] Storybook story added/updated

## How to Test
 --npm run storybook

<!-- Brief steps for reviewers -->

<!-- Closes [#EDKUI-1489] -->
